### PR TITLE
Add GitHub content calendar skill

### DIFF
--- a/.agents/skills/blog-authoring/SKILL.md
+++ b/.agents/skills/blog-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blog-authoring
-description: Use this skill when the user wants to create a new blog post, start a new article, or write a blog. This skill automates the setup of the MDX file, frontmatter, and asset directories for the ylang-labs-blog project.
+description: Use this skill when the user wants to create a new blog post, start a new article, or write a blog. This skill automates the setup of the MDX file, frontmatter, and asset directories for the ylang-labs-blog project. If the post comes from or should create a GitHub content-calendar issue, use `github-content-calendar` to preserve content type, tags, target date, end date, slug, and description metadata.
 ---
 
 # Blog Authoring Skill
@@ -12,6 +12,7 @@ This skill guides you through creating a new blog post for the `ylang-labs-blog`
 - Blog posts are stored in `data/blogs/*.mdx`.
 - Static assets (images) are stored in `public/static/images/blogs/[slug]/`.
 - Authors are defined in `data/authors/*.mdx`.
+- Calendar-tracked posts are represented by GitHub issues and Project items through `.agents/skills/github-content-calendar/SKILL.md`.
 
 ## 2. Information Gathering
 
@@ -21,6 +22,7 @@ Before creating the post, ensure you have the following information:
 - **Date**: Defaults to today's date (YYYY-MM-DD).
 - **Authors**: A list of author slugs (e.g., `arthur-reimus`, `christopher-caysido`, `ezekiel-mariano`, `van-panugan`, `default`).
 - **Tags**: A list of tags. Common tags in this project: `AI/ML`, `Agents`, `Generative AI`, `DeepSeek`, `Pydantic`, `Multi-Agent Systems`, `Context Engineering`, `RAG`.
+- **Calendar Metadata** (Optional): GitHub issue URL/number, content type, canonical tag keys from `app/blog-tag-data.json`, target date, end date, slug, priority, and description.
 - **Summary**: A short description for the blog list view.
 - **TLDR**: A "Too Long; Didn't Read" summary.
 - **Bibliography** (Optional): Path to a `.bib` file if references are used.
@@ -35,6 +37,15 @@ The project provides three distinct layouts for blog posts. Choose the one that 
 - **`PostBanner`**: Features a prominent full-width banner image at the top (uses the first image in the `images` array). It includes a "Key Takeaways" section at the start and is best for deep dives or visually-rich announcements.
 
 ## 4. Workflow
+
+### Step 0: Preserve Calendar Metadata
+
+If the user references a GitHub issue, Project item, target date, end date, or content calendar, read `.agents/skills/github-content-calendar/SKILL.md` before creating the MDX file.
+
+- Use the calendar issue description as the draft brief.
+- Use the calendar slug if one is present.
+- Convert canonical calendar tag keys to existing human-readable frontmatter tags where possible, such as `aiml` -> `AI/ML`, `agents` -> `Agents`, and `context-engineering` -> `Context Engineering`.
+- Do not invent missing schedule dates. If `Target Date` or `End Date` is absent, leave the calendar metadata incomplete and report the gap.
 
 ### Step 1: Generate the Slug
 

--- a/.agents/skills/end-to-end-blog-creation/SKILL.md
+++ b/.agents/skills/end-to-end-blog-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: end-to-end-blog-creation
-description: Orchestrate complete Ylang Labs blog creation from a user-provided blog idea or draft through generated oil-painting artwork, MDX post setup, cropped card/header images, LinkedIn/social copy, validation, and draft PR publication. Use this skill whenever the user asks to create, publish, prepare, or turn a blog idea/draft into a full Ylang Labs blog post, especially when they want artwork, blog assets, social posts, and a PR handled together.
+description: Orchestrate complete Ylang Labs blog creation from a user-provided blog idea or draft through generated oil-painting artwork, MDX post setup, cropped card/header images, LinkedIn/social copy, validation, draft PR publication, and optional GitHub content-calendar tracking. Use this skill whenever the user asks to create, publish, prepare, or turn a blog idea/draft into a full Ylang Labs blog post, especially when they want artwork, blog assets, social posts, scheduling, GitHub issues/projects, or a PR handled together.
 ---
 
 # End-to-End Blog Creation
@@ -14,19 +14,22 @@ Read and apply these skills in this order:
 1. `trending-blog-topic-research` when the user wants topic ideation before creating the post.
    - Path: `.agents/skills/trending-blog-topic-research/SKILL.md`
    - Purpose: research current technical conversations and produce exactly 5 Ylang Labs topic candidates that can be handed off into this workflow.
-2. `beautiful-oil-painting-image-gen`
+2. `github-content-calendar` when the user provides a calendar issue, asks to schedule/track the post, or wants the work represented in GitHub Issues/Projects.
+   - Path: `.agents/skills/github-content-calendar/SKILL.md`
+   - Purpose: create or update the content-calendar issue and Project item with content type, tags, target date, end date, slug, stage, and description.
+3. `beautiful-oil-painting-image-gen`
    - Path: `.agents/skills/beautiful-oil-painting-image-gen/SKILL.md`
    - Purpose: generate the source artwork or a refined generation prompt for the blog hero image.
-3. `blog-authoring`
+4. `blog-authoring`
    - Path: `.agents/skills/blog-authoring/SKILL.md`
    - Purpose: create the MDX file, frontmatter, slug, asset directory, and content structure.
-4. `blog-image-creator`
+5. `blog-image-creator`
    - Path: `.agents/skills/blog-image-creator/SKILL.md`
    - Purpose: crop the generated source artwork into `cardImage.png` and `blogHeader.png`.
-5. `blog-social-post-generator`
+6. `blog-social-post-generator`
    - Path: `.agents/skills/blog-social-post-generator/SKILL.md`
    - Purpose: create 2-3 short social post variations and save them under `posts/`.
-6. `github:yeet` when the user wants the workflow published as a PR.
+7. `github:yeet` when the user wants the workflow published as a PR.
    - Purpose: commit only scoped task files, push the branch, and open a draft PR.
 
 If one of these skills is unavailable, continue with the closest repo-native workflow and clearly state the gap.
@@ -39,6 +42,8 @@ Derive missing details from the provided blog whenever possible instead of block
 - Blog body, outline, notes, or source draft.
 - Preferred author slugs. Default to `arthur-reimus` only when the user does not specify and the repo has that author.
 - Tags. Use existing tags when possible.
+- GitHub content-calendar issue or Project item, if the work is already tracked.
+- Target date and end date when the user wants scheduling metadata.
 - Publication date. Default to today's date in `YYYY-MM-DD`.
 - Draft status. Default to `draft: false` unless the user asks for a draft article.
 - Any external references or canonical URL.
@@ -68,6 +73,7 @@ Before writing files:
 - Inspect nearby posts in `data/blogs/` for style, frontmatter, tag, reference, and component patterns.
 - Read `DESIGN.md` before making visual or layout-sensitive choices.
 - Confirm the intended slug does not already exist in `data/blogs/` or `public/static/images/blogs/`.
+- If the user references GitHub content-calendar tracking, read `.agents/skills/github-content-calendar/SKILL.md`, inspect the issue/Project item first, and preserve its content type, tags, target date, end date, slug, and description as workflow metadata.
 
 ### 2. Research Or Confirm The Topic
 
@@ -137,7 +143,18 @@ posts/social-media-<slug>.md
 
 Create 2-3 variations. For LinkedIn, prefer a professional and insight-led variation. Keep each post under 300 characters and include a `[URL]` placeholder unless the final URL is known.
 
-### 7. Validate
+### 7. Update The Content Calendar
+
+When the user asked for calendar tracking or the workflow started from a calendar issue, use `github-content-calendar` to update the GitHub issue/Project item after each meaningful handoff:
+
+- Move to `Drafting` once the MDX draft exists.
+- Move to `Assets` while source artwork, card image, and header are being produced.
+- Move to `Scheduled` when content, assets, social copy, target date, and end date are ready.
+- Move to `Published` only after the final public URL is known and linked in the issue.
+
+If Project auth is missing, continue the repo work and report the exact auth blocker from the calendar skill.
+
+### 8. Validate
 
 At minimum:
 
@@ -151,7 +168,7 @@ For code or component changes, also run `pnpm lint`.
 
 State exactly what validation ran and any gaps.
 
-### 8. Publish As A Draft PR
+### 9. Publish As A Draft PR
 
 When publishing is requested as part of the task:
 

--- a/.agents/skills/github-content-calendar/SKILL.md
+++ b/.agents/skills/github-content-calendar/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: github-content-calendar
+description: Use this skill whenever the user wants to use GitHub Issues and GitHub Projects as the Ylang Labs content calendar, including creating editorial issues, scheduling blog/project/social content, updating project calendar fields, auditing planned posts, or moving content through idea, drafting, asset, scheduled, and published stages.
+---
+
+# GitHub Content Calendar
+
+Use this skill to manage the Ylang Labs editorial calendar with GitHub Issues as content briefs and GitHub Projects as the scheduling board. The issue is the durable content brief and discussion thread; the Project item stores scheduling fields such as stage, content type, tags, target date, end date, channel, slug, and priority.
+
+## Operating Rules
+
+- Keep the repository content files as the publishing source of truth. Calendar issues track intent, status, links, and deadlines; they do not replace `data/blogs/*.mdx`, `data/projects/*.mdx`, image assets, or social-copy files.
+- Check live GitHub state before changing issues or project fields. Do not assume project numbers, field IDs, option IDs, labels, or existing issue coverage.
+- Preserve unrelated local work. Run `git status --short` before local repo edits, but most calendar work should use `gh` and not touch source files.
+- Never commit unless the user explicitly asks.
+- If GitHub Projects auth is missing, stop and report the exact refresh command. Do not guess at calendar state from stale issue lists.
+
+## Required Tooling
+
+Use the local GitHub CLI first:
+
+```bash
+gh repo view --json owner,name,url,defaultBranchRef
+gh auth status
+gh project --help
+```
+
+GitHub Projects requires project scopes. If project commands fail with missing scope errors, ask the user to authorize or run:
+
+```bash
+gh auth refresh -s read:project -s project
+```
+
+If the GitHub connector is available, it can help inspect issues and PRs, but prefer `gh project` for Project v2 field reads and mutations.
+
+## Calendar Model
+
+Default project title:
+
+```text
+Ylang Labs Content Calendar
+```
+
+Default issue title prefixes:
+
+- `[Blog] <working title>`
+- `[Project] <project/showcase title>`
+- `[Social] <campaign or post title>`
+- `[Research] <research theme>`
+
+Default project fields:
+
+- `Stage` single select: `Idea`, `Research`, `Outline`, `Drafting`, `Editing`, `Assets`, `Scheduled`, `Published`, `Parked`
+- `Content Type` single select: `Blog`, `Project`, `Newsletter`, `Social`, `Website`, `Research`
+- `Tags` text: comma-separated canonical tag slugs from `app/blog-tag-data.json` or `app/project-tag-data.json`
+- `Target Date` date: the intended publish date, launch date, or first day of the content window; this is the primary calendar date
+- `End Date` date: the final day of the content window, campaign, or completion target; for single-day items, set it equal to `Target Date`
+- `Channel` single select: `Website`, `LinkedIn`, `Twitter/X`, `Newsletter`, `GitHub`
+- `Slug` text: the expected repo slug, such as `agent-memory-evaluation-patterns`
+- `Priority` single select: `High`, `Medium`, `Low`
+
+The GitHub CLI can create projects and fields, but it does not expose a first-class command for creating a visual Calendar view. Set up the `Target Date` field through CLI, then open the Project in the browser and create or verify a Calendar view using `Target Date` when needed:
+
+```bash
+gh project view <project-number> --owner <owner> --web
+```
+
+## Tag Metadata
+
+Always load tag metadata before creating or updating a calendar item:
+
+```bash
+cat app/blog-tag-data.json
+cat app/project-tag-data.json
+```
+
+Select the tag source from the content type:
+
+- `Blog`, blog-backed `Social`, and `Newsletter` items use `app/blog-tag-data.json`.
+- `Project` and project-showcase `Website` items use `app/project-tag-data.json`.
+- `Research` items use the tag source that matches the intended downstream artifact. If unclear, record the likely tag source in the issue and ask before creating project metadata.
+
+The JSON keys are slugified tag metadata generated from existing frontmatter by `contentlayer.config.ts`. Use the keys as project metadata values, such as `aiml`, `agents`, or `context-engineering`. When writing a future MDX file, prefer the human-readable tag form already used in content frontmatter, such as `AI/ML`, `Agents`, or `Context Engineering`.
+
+If a requested topic needs a new tag that is absent from the relevant JSON file, do not invent it silently. Note the proposed new tag in the issue description and call out that the repo content/frontmatter will need to introduce it before the generated tag data will include it.
+
+## Discovery Workflow
+
+1. Identify the repo and owner:
+
+   ```bash
+   gh repo view --json owner,name,url,defaultBranchRef
+   ```
+
+2. Verify project access:
+
+   ```bash
+   gh project list --owner <owner> --format json
+   ```
+
+3. Find the content calendar project by title, or use the project named by the user:
+
+   ```bash
+   gh project list --owner <owner> --format json
+   gh project view <project-number> --owner <owner> --format json
+   gh project field-list <project-number> --owner <owner> --format json
+   ```
+
+4. Check the issue queue before creating new items:
+
+   ```bash
+   gh issue list --state all --label blog --limit 100 --json number,title,state,labels,url
+   gh issue list --state all --search "<search terms> in:title" --json number,title,state,labels,url
+   ```
+
+5. Check existing labels and create only missing labels that are needed for the task:
+
+   ```bash
+   gh label list --limit 100 --json name,color,description
+   gh label create blog --color fbca04 --description "Blog post"
+   ```
+
+   The `blog` label already exists in this repo as of the current setup. Do not rewrite existing label colors or descriptions unless the user asks.
+
+## Bootstrap A Project
+
+Only bootstrap a new project when the user asks to set up the calendar or no suitable calendar project exists and the user clearly wants one created.
+
+```bash
+gh project create --owner <owner> --title "Ylang Labs Content Calendar" --format json
+gh project field-list <project-number> --owner <owner> --format json
+```
+
+Create missing fields, not duplicates:
+
+```bash
+gh project field-create <project-number> --owner <owner> --name "Stage" --data-type SINGLE_SELECT --single-select-options "Idea,Research,Outline,Drafting,Editing,Assets,Scheduled,Published,Parked"
+gh project field-create <project-number> --owner <owner> --name "Content Type" --data-type SINGLE_SELECT --single-select-options "Blog,Project,Newsletter,Social,Website,Research"
+gh project field-create <project-number> --owner <owner> --name "Tags" --data-type TEXT
+gh project field-create <project-number> --owner <owner> --name "Target Date" --data-type DATE
+gh project field-create <project-number> --owner <owner> --name "End Date" --data-type DATE
+gh project field-create <project-number> --owner <owner> --name "Channel" --data-type SINGLE_SELECT --single-select-options "Website,LinkedIn,Twitter/X,Newsletter,GitHub"
+gh project field-create <project-number> --owner <owner> --name "Slug" --data-type TEXT
+gh project field-create <project-number> --owner <owner> --name "Priority" --data-type SINGLE_SELECT --single-select-options "High,Medium,Low"
+```
+
+After bootstrapping, report:
+
+- Project URL
+- Fields created or already present
+- Whether the calendar view still needs browser setup
+- Any auth scope gaps
+
+## Create A Content Calendar Issue
+
+Before creating an issue, dedupe by title, slug, and topic keywords. Also check the repo path if a slug is known:
+
+```bash
+gh issue list --state all --search "<working title> in:title" --json number,title,state,labels,url
+test -e data/blogs/<slug>.mdx
+test -e data/projects/<slug>.mdx
+```
+
+Use this issue body structure:
+
+```markdown
+## Metadata
+
+- Type:
+- Tags:
+- Target date:
+- End date:
+- Channel:
+- Working title:
+- Slug:
+- Owner:
+- Priority:
+
+## Description
+
+<Describe the content idea, why it matters, and what should be produced.>
+
+## Content Brief
+
+- Audience:
+- Angle:
+- Primary takeaway:
+- Source links:
+
+## Editorial Plan
+
+- Outline:
+- Assets needed:
+- References/citations:
+- Social copy:
+- PR/link when drafted:
+
+## Acceptance Criteria
+
+- [ ] Brief has a clear technical angle and target audience.
+- [ ] Draft content exists in the repo when the item moves past Drafting.
+- [ ] Required images/assets exist when the item moves past Assets.
+- [ ] `pnpm build` passes before publishing.
+- [ ] Final post/project URL is linked here before closing.
+```
+
+Create the issue:
+
+```bash
+gh issue create --title "[Blog] <working title>" --label blog --body-file <body-file>
+```
+
+Use existing labels first. For blog posts, prefer the existing `blog` label. Store the canonical metadata tags in the issue body and `Tags` project field, not as GitHub labels by default. Add new GitHub labels only when they improve filtering and the user wants the calendar taxonomy expanded.
+
+## Add Or Update Project Fields
+
+Capture IDs every time from the live project. Field IDs and option IDs are not stable across projects.
+
+```bash
+PROJECT_ID=$(gh project view <project-number> --owner <owner> --format json --jq '.id')
+STAGE_FIELD_ID=$(gh project field-list <project-number> --owner <owner> --format json --jq '.fields[] | select(.name == "Stage") | .id')
+CONTENT_TYPE_FIELD_ID=$(gh project field-list <project-number> --owner <owner> --format json --jq '.fields[] | select(.name == "Content Type") | .id')
+TAGS_FIELD_ID=$(gh project field-list <project-number> --owner <owner> --format json --jq '.fields[] | select(.name == "Tags") | .id')
+TARGET_DATE_FIELD_ID=$(gh project field-list <project-number> --owner <owner> --format json --jq '.fields[] | select(.name == "Target Date") | .id')
+END_DATE_FIELD_ID=$(gh project field-list <project-number> --owner <owner> --format json --jq '.fields[] | select(.name == "End Date") | .id')
+DRAFTING_OPTION_ID=$(gh project field-list <project-number> --owner <owner> --format json --jq '.fields[] | select(.name == "Stage") | .options[] | select(.name == "Drafting") | .id')
+BLOG_OPTION_ID=$(gh project field-list <project-number> --owner <owner> --format json --jq '.fields[] | select(.name == "Content Type") | .options[] | select(.name == "Blog") | .id')
+```
+
+Add the issue to the project and update fields:
+
+```bash
+ITEM_ID=$(gh project item-add <project-number> --owner <owner> --url <issue-url> --format json --jq '.id')
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$CONTENT_TYPE_FIELD_ID" --single-select-option-id "$BLOG_OPTION_ID"
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$TAGS_FIELD_ID" --text "aiml,agents"
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$TARGET_DATE_FIELD_ID" --date YYYY-MM-DD
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$END_DATE_FIELD_ID" --date YYYY-MM-DD
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STAGE_FIELD_ID" --single-select-option-id "$DRAFTING_OPTION_ID"
+```
+
+For a project showcase, select the `Project` content-type option and use tags from `app/project-tag-data.json`. For social or newsletter items tied to a blog post, keep `Content Type` as `Social` or `Newsletter` but use the blog tag source so the taxonomy stays aligned with the related post.
+
+For text fields:
+
+```bash
+SLUG_FIELD_ID=$(gh project field-list <project-number> --owner <owner> --format json --jq '.fields[] | select(.name == "Slug") | .id')
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$SLUG_FIELD_ID" --text "<slug>"
+```
+
+For an existing project item, list items and find the matching issue URL or issue number:
+
+```bash
+gh project item-list <project-number> --owner <owner> --limit 100 --format json
+```
+
+Then edit the matching `ITEM_ID` with the same `gh project item-edit` commands.
+
+## Stage Semantics
+
+- `Idea`: topic exists but needs sharpening.
+- `Research`: needs trend, citation, or competitor/source research.
+- `Outline`: angle approved, structure not drafted.
+- `Drafting`: MDX or project page is being written.
+- `Editing`: draft exists and needs review, polish, or citations.
+- `Assets`: text direction is stable and images/diagrams/social assets are being prepared.
+- `Scheduled`: final content is ready or queued with a publish date.
+- `Published`: content is live; issue should link the final URL and related PR.
+- `Parked`: intentionally deferred.
+
+When a calendar item becomes active blog production, use the repo skills instead of reimplementing the workflow:
+
+- `trending-blog-topic-research` for topic discovery.
+- `end-to-end-blog-creation` for turning an approved idea into a full post with artwork, assets, social copy, validation, and PR publication.
+- `blog-authoring` for focused MDX setup when full end-to-end creation is not needed.
+
+## Audit And Reporting
+
+For a calendar audit, list active project items and group them by stage and publish date:
+
+```bash
+gh project item-list <project-number> --owner <owner> --limit 100 --format json
+```
+
+Report:
+
+- Overdue items: `Target Date` before today and not `Published` or `Parked`.
+- Missing dates: items in `Outline`, `Drafting`, `Editing`, `Assets`, or `Scheduled` without `Target Date` or `End Date`.
+- Missing tags: items without `Tags`, or with tags that are absent from the relevant `app/blog-tag-data.json` or `app/project-tag-data.json`.
+- Missing slugs: website content without `Slug`.
+- Broken execution links: items in `Drafting` or later without a repo path, branch, PR, or draft link.
+- Published-but-open items: `Published` stage with an open issue and no clear follow-up reason.
+
+Keep the report actionable: include issue links, content type, tags, current stage, target date, end date, and the next concrete action.
+
+## Final Response
+
+When you create or update calendar items, include:
+
+- Issue URL
+- Project URL or project number
+- Fields changed
+- Content type, tags, target date, end date, and description status
+- Any scope/auth blockers
+- Any manual calendar-view setup still needed
+
+Do not bury blockers. If project mutation failed because of missing auth scopes, say that explicitly and provide the refresh command.

--- a/.agents/skills/github-content-calendar/SKILL.md
+++ b/.agents/skills/github-content-calendar/SKILL.md
@@ -7,6 +7,8 @@ description: Use this skill whenever the user wants to use GitHub Issues and Git
 
 Use this skill to manage the Ylang Labs editorial calendar with GitHub Issues as content briefs and GitHub Projects as the scheduling board. The issue is the durable content brief and discussion thread; the Project item stores scheduling fields such as stage, content type, tags, target date, end date, channel, slug, and priority.
 
+GitHub Issues do not have native custom fields. Mirror the content type onto the issue with labels such as `type: blog` and `type: project`, then store the richer metadata in both the issue body and the Project item fields.
+
 ## Operating Rules
 
 - Keep the repository content files as the publishing source of truth. Calendar issues track intent, status, links, and deadlines; they do not replace `data/blogs/*.mdx`, `data/projects/*.mdx`, image assets, or social-copy files.
@@ -118,9 +120,11 @@ If a requested topic needs a new tag that is absent from the relevant JSON file,
    ```bash
    gh label list --limit 100 --json name,color,description
    gh label create blog --color fbca04 --description "Blog post"
+   gh label create "type: blog" --color 1d76db --description "Content calendar item: blog"
+   gh label create "type: project" --color 5319e7 --description "Content calendar item: project"
    ```
 
-   The `blog` label already exists in this repo as of the current setup. Do not rewrite existing label colors or descriptions unless the user asks.
+   The `blog` label already exists in this repo as of the current setup. Do not rewrite existing label colors or descriptions unless the user asks. Add `type: blog` or `type: project` to calendar issues so content type remains visible on the issue page and issue lists, even outside the Project view.
 
 ## Bootstrap A Project
 
@@ -168,8 +172,8 @@ Use this issue body structure:
 
 - Type:
 - Tags:
-- Target date:
-- End date:
+- Target date: TBD
+- End date: TBD
 - Channel:
 - Working title:
 - Slug:
@@ -207,10 +211,10 @@ Use this issue body structure:
 Create the issue:
 
 ```bash
-gh issue create --title "[Blog] <working title>" --label blog --body-file <body-file>
+gh issue create --title "[Blog] <working title>" --label blog --label "type: blog" --body-file <body-file>
 ```
 
-Use existing labels first. For blog posts, prefer the existing `blog` label. Store the canonical metadata tags in the issue body and `Tags` project field, not as GitHub labels by default. Add new GitHub labels only when they improve filtering and the user wants the calendar taxonomy expanded.
+Use existing labels first. For blog posts, prefer the existing `blog` label plus `type: blog`. For project-showcase topics, use `type: project`. Store canonical metadata tags such as `aiml` and `agents` in the issue body and `Tags` project field, not as GitHub labels by default.
 
 ## Add Or Update Project Fields
 
@@ -237,6 +241,8 @@ gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$TAR
 gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$END_DATE_FIELD_ID" --date YYYY-MM-DD
 gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STAGE_FIELD_ID" --single-select-option-id "$DRAFTING_OPTION_ID"
 ```
+
+Only set `Target Date` and `End Date` on the Project item when real dates are known. If the user has not provided dates, write `TBD` in the issue body metadata and leave the Project date fields blank.
 
 For a project showcase, select the `Project` content-type option and use tags from `app/project-tag-data.json`. For social or newsletter items tied to a blog post, keep `Content Type` as `Social` or `Newsletter` but use the blog tag source so the taxonomy stays aligned with the related post.
 
@@ -285,6 +291,7 @@ Report:
 
 - Overdue items: `Target Date` before today and not `Published` or `Parked`.
 - Missing dates: items in `Outline`, `Drafting`, `Editing`, `Assets`, or `Scheduled` without `Target Date` or `End Date`.
+- Missing type labels: issues without `type: blog` or `type: project` when the item is a blog or project-showcase topic.
 - Missing tags: items without `Tags`, or with tags that are absent from the relevant `app/blog-tag-data.json` or `app/project-tag-data.json`.
 - Missing slugs: website content without `Slug`.
 - Broken execution links: items in `Drafting` or later without a repo path, branch, PR, or draft link.

--- a/.agents/skills/github-content-calendar/SKILL.md
+++ b/.agents/skills/github-content-calendar/SKILL.md
@@ -25,10 +25,10 @@ gh auth status
 gh project --help
 ```
 
-GitHub Projects requires project scopes. If project commands fail with missing scope errors, ask the user to authorize or run:
+GitHub Projects requires the `project` OAuth scope. If project commands fail with missing scope errors, ask the user to authorize or run:
 
 ```bash
-gh auth refresh -s read:project -s project
+gh auth refresh -s project
 ```
 
 If the GitHub connector is available, it can help inspect issues and PRs, but prefer `gh project` for Project v2 field reads and mutations.

--- a/.agents/skills/trending-blog-topic-research/SKILL.md
+++ b/.agents/skills/trending-blog-topic-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trending-blog-topic-research
-description: Autonomously research current technical conversations across Hacker News, Twitter/X, Reddit, and supporting web sources, then propose exactly 5 strong Ylang Labs blog topic candidates. Use this skill whenever the user asks for trending blog ideas, topic research, what to write about next, Hacker News/Twitter/Reddit trend scans, content ideation from social signals, or a shortlist of possible posts.
+description: Autonomously research current technical conversations across Hacker News, Twitter/X, Reddit, and supporting web sources, then propose exactly 5 strong Ylang Labs blog topic candidates. Use this skill whenever the user asks for trending blog ideas, topic research, what to write about next, Hacker News/Twitter/Reddit trend scans, content ideation from social signals, or a shortlist of possible posts. If the user wants those topics added to the GitHub content calendar, handed off as issues, scheduled, or tracked, use `github-content-calendar` after the shortlist is produced.
 ---
 
 # Trending Blog Topic Research
@@ -87,7 +87,22 @@ Use recency filters when available. For trend research, default to the last 7-14
 
 7. Prepare next-step handoff.
    - If the user wants to proceed with one topic, hand off to `blog-authoring` or `end-to-end-blog-creation`.
+   - If the user wants the shortlist or selected topic tracked in GitHub, hand off to `github-content-calendar` at `.agents/skills/github-content-calendar/SKILL.md`.
    - If working inside the Ylang Labs blog repo, save the final shortlist to `posts/topic-research-YYYY-MM-DD.md` unless the user asked for chat-only output or the environment is read-only.
+
+## Content Calendar Handoff
+
+When the user asks to add researched topics to the content calendar, read `github-content-calendar` and create or update GitHub issues after the research output is complete.
+
+For each calendarized topic, map the research output into:
+
+- `Type`: `Blog` unless the user specifies `Project`, `Social`, `Newsletter`, `Website`, or `Research`.
+- `Tags`: canonical keys from `app/blog-tag-data.json`, such as `aiml`, `agents`, `generative-ai`, `context-engineering`, or `security`.
+- `Target Date` and `End Date`: use explicit user-provided dates; if absent, leave them blank in the issue metadata rather than inventing a schedule.
+- `Description`: use the topic thesis, why-now signal, and Ylang angle.
+- `Content Brief`: use the proposed article shape, source links, risks, and demo/diagram idea.
+
+Do not create duplicate issues. Search existing open and closed issues by title, slug, and core topic terms before creating anything.
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

- Add `github-content-calendar` as a repo-local skill for using GitHub Issues and Projects as the content calendar.
- Link the calendar workflow from `blog-authoring`, `end-to-end-blog-creation`, and `trending-blog-topic-research` only.
- Keep calendar metadata aligned with existing blog/project tag metadata, target/end dates, slug, stage, and description fields.

## Validation

- `git diff --cached --check`
- Scoped PR diff verified with `git diff --name-only origin/main...HEAD`

## Notes

- The live GitHub Project has already been set up at https://github.com/users/artreimus/projects/4.
- GitHub CLI does not expose first-class Calendar view creation, so the visual Calendar view still needs to be created in the GitHub UI using `Target Date`.