### PR TITLE
Add context graph references and image guidance

### DIFF
--- a/.agents/skills/blog-image-cropper/SKILL.md
+++ b/.agents/skills/blog-image-cropper/SKILL.md
@@ -21,6 +21,8 @@ Create both files unless the user explicitly asks for only one:
 
 Use PNG. Keep filenames exact because blog frontmatter expects these names.
 
+When this workflow creates or normalizes the reusable source artwork, keep `source-artwork.png` square (`1:1`) unless the user explicitly requests another source format. The source image is the master artwork for future crops, so it should not be saved as a header-shaped or card-shaped derivative.
+
 ## Core Rule
 
 Do not blindly resize or center-crop.
@@ -47,6 +49,8 @@ Before editing, inspect the source image with `view_image` or another visual ins
 For Ylang Labs blog art, the preferred house style remains a beautiful painting-like background with a central conceptual illustration or diagram. When the provided image already has that structure, preserve it. When it does not, still crop it cleanly; do not invent new artwork unless the user asks for generation.
 
 If no source artwork has been provided yet, generate or prompt the source artwork through `.agents/skills/oil-painting-image-generator/SKILL.md` before creating `cardImage.png` and `blogHeader.png`. The card and header should come from that oil-painting source artwork unless the user explicitly asks for a different style or supplies an image that must be used.
+
+For generated source artwork, prefer a square `1:1` composition with the main subject near the center and enough breathing room on all sides. If the available source artwork is not square and the task includes preparing the source image itself, first create a visually intentional square `source-artwork.png`, then derive the required card and header crops from it.
 
 ## Crop Strategy
 
@@ -115,6 +119,7 @@ Use judgment instead of forcing a bad crop:
 
 5. Verify.
    - Confirm exact dimensions with `sips -g pixelWidth -g pixelHeight` or equivalent.
+   - Confirm generated or normalized `source-artwork.png` is square (`1:1`) unless the user requested another source format.
    - Visually inspect both final images.
    - Re-crop if the subject is awkwardly cut off, text is unreadable, or the composition feels accidental.
 
@@ -160,6 +165,7 @@ Pick `left`, `top`, `width`, and `height` from the source image dimensions after
 
 Before finalizing, confirm:
 
+- `source-artwork.png` is square (`1:1`) when the task includes creating or normalizing source artwork.
 - `cardImage.png` is exactly `1080x1920`.
 - `blogHeader.png` is exactly `1260x700`.
 - Both outputs come from the provided image.

--- a/.agents/skills/oil-painting-image-generator/SKILL.md
+++ b/.agents/skills/oil-painting-image-generator/SKILL.md
@@ -31,10 +31,12 @@ When creating Ylang Labs blog artwork, use this skill to generate the source pai
 Required flow:
 
 1. Create a refined oil-painting prompt for the article's central technical metaphor.
-2. Generate or save the source artwork as `public/static/images/blogs/[slug]/source-artwork.png`.
+2. Generate or save the source artwork as `public/static/images/blogs/[slug]/source-artwork.png` using a square `1:1` aspect ratio.
 3. Use `blog-image-cropper` to crop the source artwork into:
    - `cardImage.png` at exactly `1080x1920`
    - `blogHeader.png` at exactly `1260x700`
+
+The source painting should be a square master image, ideally `1536x1536` or larger when the generation tool allows it. A square source gives the cropper enough vertical and horizontal room to create both the portrait card and wide header without privileging one target format too early.
 
 The source painting should work in both portrait and wide crops: place the main subject near the center, preserve readable negative space around the subject, avoid important details near the edges, and avoid any text or logo-like marks because the crop targets are reused across listings, social cards, and the PostBanner hero.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,10 +120,11 @@ Blog asset standards:
 - Store assets in `public/static/images/blogs/<slug>/`.
 - Use `cardImage.png` for listing/card thumbnails.
 - Use `blogHeader.png` for the post banner.
+- Use `source-artwork.png` as the reusable master artwork for generated/cropped blog art. Keep it square (`1:1`), ideally `1536x1536` or larger when the generation tool allows it, unless the user explicitly requests another source format.
 - Use descriptive names for inline images, diagrams, and figures.
 - Reference images with absolute public paths such as `/static/images/blogs/<slug>/diagram.png`.
 - For generated cover/card/header art, create the source artwork with `oil-painting-image-generator` first unless the user explicitly asks for another cover style.
-- For generated/cropped blog art, `cardImage.png` should be `1080x1920` and `blogHeader.png` should be `1260x700` unless the user explicitly asks otherwise.
+- For generated/cropped blog art, derive `cardImage.png` and `blogHeader.png` from the square `source-artwork.png`; `cardImage.png` should be `1080x1920` and `blogHeader.png` should be `1260x700` unless the user explicitly asks otherwise.
 - For section-level diagrams, architecture plates, process maps, and inline technical figures, use `technical-blog-image-generator`.
 - Do not create SVG/vector/code-native image sources unless the user explicitly asks for manual vector work.
 

--- a/data/blogs/context-graphs-ai-trillion-dollar-opportunity.mdx
+++ b/data/blogs/context-graphs-ai-trillion-dollar-opportunity.mdx
@@ -125,3 +125,11 @@ That makes the best wedge less likely to be "a general memory layer for all agen
 Start narrow. Capture the trace. Make precedent queryable. Prove that future decisions get faster or more defensible.
 
 If that works, the graph becomes more than context for the model. It becomes context for the company.
+
+## References
+
+1. [Foundation Capital, "AI's trillion-dollar opportunity: Context graphs"](https://foundationcapital.com/ideas/context-graphs-ais-trillion-dollar-opportunity)
+2. [Neo4j, "Graph database concepts"](https://neo4j.com/docs/getting-started/appendix/graphdb-concepts/)
+3. [Neo4j, "Introducing Create Context Graph"](https://neo4j.com/blog/genai/introducing-create-context-graph/)
+4. [Neo4j, "AI Systems"](https://neo4j.com/use-cases/ai-systems/)
+5. [Cognee Documentation, "Introduction"](https://docs.cognee.ai/getting-started/introduction)


### PR DESCRIPTION
## Summary
- add a visible References section to the context graphs blog post
- document that generated blog source artwork should be a square 1:1 master image
- mirror the square source-artwork rule into the image cropper and oil-painting skills

## Validation
- git diff --check
- NEXT_PUBLIC_WEB3_FORMS_ACCESS_KEY=dummy pnpm build
- sub-agent review passed with no findings for the references section