### PR TITLE
[codex] Refine blog voice guidelines

### DIFF
--- a/.agents/skills/blog-mdx-authoring/SKILL.md
+++ b/.agents/skills/blog-mdx-authoring/SKILL.md
@@ -20,14 +20,14 @@ This skill guides you through creating a new blog post for the `ylang-labs-blog`
 
 Before creating the post, ensure you have the following information:
 
-- **Title**: The title of the blog post.
+- **Title**: The title of the blog post. Prefer an ambitious, specific title that sells the thesis, tension, or payoff instead of a neutral topic label.
 - **Date**: Defaults to today's date (YYYY-MM-DD).
 - **Authors**: A list of author slugs (e.g., `arthur-reimus`, `christopher-caysido`, `ezekiel-mariano`, `van-panugan`, `default`).
 - **Tags**: A list of tags. Common tags in this project: `AI/ML`, `Agents`, `Generative AI`, `DeepSeek`, `Pydantic`, `Multi-Agent Systems`, `Context Engineering`, `RAG`.
 - **Calendar Metadata** (Optional): GitHub issue URL/number, content type, canonical tag keys from `app/blog-tag-data.json`, target date, end date, slug, priority, and description.
-- **Summary**: A short description for the blog list view.
-- **TLDR**: Multi-bullet key takeaways for `PostBanner`. Do not duplicate these as a manual "Key Takeaways" section in the body.
-- **Style Direction**: Read `.agents/skills/blog-writing-guide/SKILL.md` before drafting or revising Ylang Labs blog prose.
+- **Summary**: A short description for the blog list view. It should give a concrete reason to click by saying what the reader will understand, build, fix, or decide after reading.
+- **TLDR**: Multi-bullet key takeaways for `PostBanner`. Write bullets as useful conclusions, not neutral recaps. Do not duplicate these as a manual "Key Takeaways" section in the body.
+- **Style Direction**: Read `.agents/skills/blog-writing-guide/SKILL.md` before drafting or revising blog prose. Use The Pragmatic Engineer-inspired standard by default.
 - **Reading Time**: Default to 5 minutes or less unless the user explicitly asks for or approves a longer post.
 - **Reference Topic**: A kebab-case folder name under `refs/`. Default to the final blog slug; use a working topic slug while researching if the title is not final.
 - **Bibliography** (Optional): Path to a `.bib` file if references are used.
@@ -99,7 +99,9 @@ Optional generated-art sequence:
 
 ### Step 5: Create the MDX File
 
-Use `.agents/skills/blog-writing-guide/SKILL.md` before drafting the `summary`, `tldr`, and article body. Keep this skill responsible for file structure, frontmatter, asset paths, and MDX conventions; let `blog-writing-guide` shape the opening, reader-question structure, technical depth, section headings, banned-language cleanup, and editorial review pass.
+Use `.agents/skills/blog-writing-guide/SKILL.md` before drafting the `title`, `summary`, `tldr`, and article body. Keep this skill responsible for file structure, frontmatter, asset paths, and MDX conventions; let `blog-writing-guide` shape the Pragmatic Engineer-inspired voice, ambition level, opening, reader-question structure, technical depth, section headings, banned-language cleanup, and editorial review pass.
+
+After the body has a clear thesis, revisit the `title`, `summary`, and `tldr`. These are part of the blog's packaging, not clerical metadata. They should sell the strongest defensible claim in the post.
 
 Create the file `data/blogs/[slug].mdx` with the following frontmatter:
 
@@ -251,6 +253,7 @@ The project uses `refs/[slug]/` as the source-of-truth workspace for research pr
 - Confirm `refs/[slug]/README.md` exists when the post relies on external sources or research.
 - Confirm the file `data/blogs/[slug].mdx` exists with the correct frontmatter.
 - Confirm rendered citations in `data/references-data.bib` or the MDX `## References` section line up with the source log in `refs/[slug]/README.md`.
-- Confirm the draft passes `blog-writing-guide`: it opens with the problem or conclusion, stays at 5 minutes or less by default, uses the correct post-type scaffold, has specific headings, includes concrete technical detail, explains tradeoffs or limitations where relevant, avoids banned language, and ends with a useful next step.
+- Confirm the draft passes `blog-writing-guide`: it uses the Pragmatic Engineer-inspired voice, opens with the problem or conclusion, stays at 5 minutes or less by default, uses the correct post-type scaffold, has specific headings, includes concrete technical detail, explains tradeoffs or limitations where relevant, avoids banned language, and ends with a useful next step.
+- Confirm the `title`, `summary`, and `tldr` are ambitious enough to sell the post while remaining defensible from the article body.
 - Confirm `PostBanner` posts do not duplicate the rendered "Key Takeaways" callout with a manual body section.
 - Confirm `cardImage.png` and `blogHeader.png` exist when frontmatter references them, or clearly report that the image assets still need to be created.

--- a/.agents/skills/blog-publishing-workflow/SKILL.md
+++ b/.agents/skills/blog-publishing-workflow/SKILL.md
@@ -19,7 +19,7 @@ Read and apply these skills in this order:
    - Purpose: create or update the content-calendar issue and Project item with content type, tags, target date, end date, slug, stage, and description.
 3. `blog-writing-guide`
    - Path: `.agents/skills/blog-writing-guide/SKILL.md`
-   - Purpose: apply the primary Ylang Labs blog voice, structure, technical quality bar, banned-language rules, title guidance, and review checklist before the MDX draft is finalized.
+   - Purpose: apply the primary Pragmatic Engineer-inspired voice, ambition-without-hype standard, structure, technical quality bar, banned-language rules, title guidance, and review checklist before the MDX draft is finalized.
 4. `blog-mdx-authoring`
    - Path: `.agents/skills/blog-mdx-authoring/SKILL.md`
    - Purpose: create the MDX file, frontmatter, slug, asset directory, and content structure.
@@ -52,7 +52,7 @@ Derive missing details from the provided blog whenever possible instead of block
 - Target date and end date when the user wants scheduling metadata.
 - Publication date. Default to today's date in `YYYY-MM-DD`.
 - Draft status. Default to `draft: false` unless the user asks for a draft article.
-- Style direction. Default to `blog-writing-guide` for all Ylang Labs blog prose.
+- Style direction. Default to `blog-writing-guide` for all blog prose. The Pragmatic Engineer-inspired standard is the default.
 - Reading time. Default to 5 minutes or less unless the user explicitly asks for or approves a longer post.
 - Any external references or canonical URL.
 - Reference topic slug for `refs/<topic>/`. Default to the final blog slug when the user does not provide one.
@@ -111,8 +111,8 @@ Use `blog-mdx-authoring` to:
 - Set:
   - `cardImage: '/static/images/blogs/<slug>/cardImage.png'`
   - `images: ['/static/images/blogs/<slug>/blogHeader.png']`
-- Use `summary` for the listing/SEO summary.
-- Use `tldr` for concise Key Takeaways.
+- Use `summary` for the listing/SEO summary, and make it concrete enough to sell why the post is worth reading.
+- Use `tldr` for concise Key Takeaways, written as useful conclusions rather than neutral recaps.
 - Use existing MDX components such as `Callout`, `Image`, `DiagramSubtitle`, and `MermaidDiagram` when they make the article clearer.
 - Choose the body scaffold by post type:
   - Engineering deep dive: problem, mechanism, architecture, tradeoffs, failure modes, practical application, references.
@@ -124,6 +124,8 @@ Keep the article concrete and technical. Prefer implementation details, architec
 
 Apply `blog-writing-guide` before finalizing the MDX draft:
 
+- Use the Pragmatic Engineer-inspired voice: direct, concrete, technically sharp, inside-view, source-backed, and grounded in shipped-work judgment.
+- Sell the strongest defensible thesis through the title, opening, summary, and TLDR.
 - Keep the draft at 5 minutes or less by default unless the user explicitly asked for or approved a longer post.
 - Open by stating the problem or conclusion in the first 2-3 sentences.
 - Structure the article around the reader's questions: problem, mechanics, tradeoffs, implementation, failed attempts, and known limitations where relevant.
@@ -191,7 +193,7 @@ posts/social-media-<slug>.md
 
 Create 2-3 variations. For LinkedIn, prefer a professional, insight-led narrative variation in the 500-900 character range with short paragraphs, concrete technical stakes, and a natural CTA. Include one short X/Twitter-ready variation only when useful, and include a `[URL]` placeholder unless the final URL is known.
 
-Use `blog-writing-guide` as the baseline voice for social copy: specific, direct, technically useful, and free of generic hype.
+Use `blog-writing-guide` as the baseline voice for social copy: Pragmatic Engineer-inspired, specific, direct, technically useful, ambitious without generic hype, and anchored in the post's strongest defensible claim.
 
 ### 7. Update The Content Calendar
 

--- a/.agents/skills/blog-social-copy/SKILL.md
+++ b/.agents/skills/blog-social-copy/SKILL.md
@@ -7,9 +7,13 @@ description: Generate exciting, thesis-driven social launch copy for Ylang Labs 
 
 Use this skill to create exciting, specific social media variations for blogs or project updates.
 
-The default output should feel like a strong founder or technical-builder post: clear thesis, concrete stakes, practical implication, and a direct pointer to the article. It should make a reader feel that something in the technical landscape is shifting, then quickly show what the post explains.
+The default social-copy standard is The Pragmatic Engineer by Gergely Orosz as an editorial reference. Do not imitate his exact prose, recurring phrasing, or author persona.
+
+The default output should feel like a Pragmatic Engineer-inspired post with founder-level ambition: clear thesis, concrete stakes, practical implication, and a direct pointer to the article. It should make a reader feel that something in the technical landscape is shifting, then quickly show what the post explains and why it is worth their time.
 
 Do not make the copy sound like a generic announcement, SEO snippet, newsletter blurb, or press release.
+
+Sell the blog by selling the problem, mechanism, or shift. Do not merely announce that Ylang Labs wrote something.
 
 ## Core Mandates
 
@@ -18,6 +22,10 @@ Do not make the copy sound like a generic announcement, SEO snippet, newsletter 
   2. A concrete explanation of what changed, why it matters, or what the reader can now build.
   3. At least one practical implication, such as latency, privacy, cost, deployment, reliability, evaluation, or developer workflow.
   4. A clear CTA with `[URL]` unless the final URL is known.
+- **Ambition:** The hook should make a bold, defensible claim about an engineering shift, failure mode, or payoff. Avoid neutral topic summaries.
+- **Proof Anchor:** Every ambitious claim needs at least one concrete anchor from the article: a named model, paper, product, framework, architecture, workflow, number, tradeoff, or failure mode.
+- **Reader Payoff:** Make clear what the reader will understand, build, fix, avoid, or decide after clicking.
+- **Inside-View Signal:** When the article supports it, include a specific operating detail: scale, architecture, migration path, incident pattern, team workflow, evaluation result, or cost/reliability implication.
 - **Default LinkedIn Shape:** Prefer the pattern:
   1. One-line thesis.
   2. A short paragraph grounding the thesis in a model, architecture, workflow, or problem.
@@ -28,13 +36,14 @@ Do not make the copy sound like a generic announcement, SEO snippet, newsletter 
   - LinkedIn: 500-900 characters by default, with short paragraphs and no filler.
   - X/Twitter: 240-280 characters when a short variant is requested.
   - Generic social launch copy: 400-700 characters.
-- **Tone:** Engaging, conversational, technically credible, and platform-appropriate. Aim for "this is worth reading" energy, not corporate enthusiasm.
+- **Tone:** Engaging, conversational, technically credible, and platform-appropriate. Aim for "this changes how I think about the problem" energy, not corporate enthusiasm.
 - **Specificity:** Name the model, paper, product, technique, benchmark, or architecture when it is central to the post. Avoid vague claims like "game changer," "major upgrade," and "unlocking the future" unless the copy immediately proves the claim with specifics.
 - **Excitement:** Create momentum through stakes and implications, not through hype words or excessive punctuation.
 - **Point of View:** Make the post about the shift, not merely about the fact that Ylang Labs published something. The CTA can mention the blog, but the first line should usually name the technical idea.
+- **Pragmatic Engineer Voice:** Lead with judgment, then support it with implementation detail. Use plain words, short paragraphs, and decisive claims. Do not posture. Do not hide behind vague futurism.
 - **Variations:** Always provide 2-3 distinct variations.
 - **Formatting:** Prefer 3-5 short paragraphs for LinkedIn. Avoid hashtags by default. Avoid emojis by default unless the user asks for a playful tone or the post clearly benefits from one.
-- **Voice:** Use plain words, short paragraphs, and decisive claims. Avoid "we're excited to share," "check out," "game changer," "unlock the future," and exclamation-mark-driven excitement.
+- **Banned Phrases:** Avoid "we're excited to share," "check out," "game changer," "unlock the future," and exclamation-mark-driven excitement.
 
 ## Hook Patterns
 
@@ -45,6 +54,11 @@ Use one of these patterns when drafting the first line:
 - **Constraint reversal:** "`[Old constraint]` used to be the default. `[...]` changes that."
 - **Builder implication:** "If `[technical shift]` is true, then `[new product/workflow]` becomes possible."
 - **Memory/compounding:** "`[System]` gets better when it has somewhere to put what it learns."
+- **Hidden bottleneck:** "`[Obvious problem]` is not the bottleneck. `[Less obvious constraint]` is."
+- **Failure mode:** "Most `[teams/systems]` do not fail because `[common explanation]`. They fail because `[specific cause]`."
+- **Market bet:** "The next generation of `[tool/category]` will be judged by `[technical criterion]`."
+- **Inside-view:** "Inside `[system/product/team]`: `[specific mechanism]` is doing more work than it looks like."
+- **Numbers-first:** "`[Scale number]` changes the architecture. Here is the part that breaks first."
 
 The hook should be understandable without the rest of the post. If it only works after someone reads paragraph two, rewrite it.
 
@@ -101,13 +115,14 @@ The project update is here: [URL]
 1.  Analyze the provided blog content or project summary.
 2.  Extract the key value proposition or most interesting insight.
 3.  Identify the strongest "what changed" claim before drafting. This is usually more compelling than the topic label.
-4.  Draft 3 variations:
+4.  Identify the proof anchor that makes the strongest claim defensible.
+5.  Draft 3 variations:
     - **Variation 1: LinkedIn Narrative**: 500-900 characters. Lead with a thesis, explain the technical shift, name practical implications, then close with a CTA.
     - **Variation 2: Punchy Short Post**: 240-280 characters. Compress the strongest claim into a short X/Twitter-ready post.
     - **Variation 3: Curiosity Hook**: 400-700 characters. Start with a question or tension, then explain what the post resolves.
-5.  Make the LinkedIn variation the strongest default option, not merely the longest option.
-6.  Include placeholders like `[URL]` for links unless the final URL is provided. If the user provides a real URL, use it exactly.
-7.  Save the variations into a markdown file in the `/posts/` directory (e.g., `/posts/social-media-[topic].md`).
+6.  Make the LinkedIn variation the strongest default option, not merely the longest option.
+7.  Include placeholders like `[URL]` for links unless the final URL is provided. If the user provides a real URL, use it exactly.
+8.  Save the variations into a markdown file in the `/posts/` directory (e.g., `/posts/social-media-[topic].md`).
 
 ## Quality Checklist
 
@@ -115,6 +130,7 @@ Before finalizing, verify:
 
 - The first line can stand alone as an interesting social hook.
 - The post says what changed, not just what the article is about.
+- The hook is ambitious enough to be worth sharing, but the article gives it a proof anchor.
 - The implications are concrete enough that a technical reader understands why to click.
 - The CTA feels natural and specific to the post.
 - The LinkedIn version is not constrained by tweet-length rules.

--- a/.agents/skills/blog-writing-guide/SKILL.md
+++ b/.agents/skills/blog-writing-guide/SKILL.md
@@ -11,15 +11,45 @@ This is the primary Ylang Labs blog writing skill. It enforces Ylang Labs' blog 
 
 What follows are the core principles to internalize and apply to every piece of content.
 
-## The Ylang Labs Voice
+## The Default Voice
 
-**We sound like:** A senior developer at a conference afterparty explaining something they're genuinely excited about — smart, specific, a little irreverent, deeply knowledgeable.
+The default Ylang Labs blog writing standard is [The Pragmatic Engineer](https://www.pragmaticengineer.com/) by Gergely Orosz.
 
-**We don't sound like:** A corporate blog, a press release, a sales deck, or an AI-generated summary.
+Use it as the editorial reference, not a prose clone. Do not imitate Gergely Orosz's exact wording, recurring phrasing, personal cadence, or author persona.
 
-Be technically precise, opinionated, and direct. Humor is welcome but should serve the content, not replace it. Sarcasm works. One good joke per post is plenty.
+**We sound like:** A Pragmatic Engineer-inspired author who has shipped the thing, debugged the failure modes, and is explaining the useful part to another capable builder. Calm, concrete, technically sharp, and direct.
 
-Use "we" (Ylang Labs) and "you" (the reader). This is a conversation, not a paper.
+**We don't sound like:** A corporate blog, a press release, a sales deck, a hype thread with no implementation detail, or an AI-generated summary.
+
+Write as someone trying to save a strong engineer time. Make the claim early, say why it matters now, show the mechanism, name the tradeoffs, and give the reader a practical way to use the idea.
+
+Use "we" and "you" when useful. This is a conversation between engineers, not a paper.
+
+Personality should come from judgment, specificity, and useful asides. Prefer dry confidence over banter. Humor is welcome only when it sharpens the point. Do not force jokes or sarcasm.
+
+Use these Pragmatic Engineer-inspired editorial traits:
+
+- **Inside view:** Prefer how the system, team, workflow, or market actually works over generic opinion.
+- **Numbers early:** Put scale, cost, latency, adoption, throughput, revenue, failure rate, or time saved near the top when available.
+- **Named specifics:** Name the model, product, framework, architecture, team shape, constraint, or migration path.
+- **Source-backed claims:** Use interviews, docs, code, benchmarks, issues, release notes, papers, or credible reporting. Label inference clearly.
+- **Engineering plus business context:** Explain why the technical choice matters for users, teams, budgets, reliability, hiring, or strategy.
+- **Tradeoffs over cheerleading:** Say what worked, what did not, what was chosen instead, and why.
+- **Operational detail:** Show how a team would build, deploy, debug, measure, or roll back the idea in practice.
+
+## Ambition Without Hype
+
+Posts should be pragmatic, but not timid. Sell the strongest credible thesis behind the work.
+
+This applies to the article body and to the packaging around it:
+
+- **Title:** Sell the thesis, not the topic label. The title should imply a tension, payoff, or shift.
+- **Opening:** State what changed, what became possible, or what mistake the reader can now avoid in the first 2-3 sentences.
+- **Summary:** Give a concrete reason to click. Say what the reader will understand, build, fix, or decide after reading.
+- **TLDR:** Write bullets as useful conclusions, not neutral recaps.
+- **Social copy:** Promote the strongest claim from the post, not the fact that Ylang Labs published a post.
+
+Ambition has to cash out. Every bold claim needs at least one mechanism, example, number, source, tradeoff, or caveat inside the post. If the title is more interesting than the article, revise the article or lower the title.
 
 ## Banned Language
 
@@ -61,9 +91,9 @@ Use this rule while drafting and editing:
 
 ## The Opening (First 2-3 Sentences)
 
-The opening must do one of two things: **state the problem** or **state the conclusion**. Never start with background, company history, or hype.
+The opening must state the problem or conclusion, and it should make the stakes obvious. Never start with background, company history, or hype.
 
-**Good:** "Two weeks before launch, we killed our entire metrics product. Here's why pre-aggregating time-series metrics breaks down for debugging, and how we rebuilt the system from scratch."
+**Good:** "Two weeks before launch, we killed our entire metrics product. Pre-aggregated time-series metrics were fast, but they threw away the debugging context our users needed most."
 
 **Bad:** "At Ylang Labs, we're always looking for ways to improve the developer experience. Today, we're thrilled to share some exciting updates to our metrics product that we think you'll love."
 
@@ -179,19 +209,38 @@ LLM-generated prose has tells. Flag and rewrite these:
 
 ## Title Guidelines
 
-The title is the highest-leverage sentence in the post. It must stop a developer scrolling through their RSS feed or Twitter.
+The title is the highest-leverage sentence in the post. It must stop a developer scrolling through their RSS feed, LinkedIn, or Twitter/X.
 
-**Strong titles** make a specific claim, tell a story, or promise a specific payoff:
+Ylang Labs titles should be ambitious and specific. They should make a capable engineer think, "I need to know how they pulled that off," or "I may be making that mistake."
+
+**Strong titles** make a specific claim, expose a hidden failure mode, tell a story, or promise a concrete payoff:
 
 - "The metrics product we built worked. But we killed it and started over anyway"
 - "How we reduced release delays by 5% by fixing Salt"
 - "Your JavaScript bundle has 47% dead code. Here's how to find it."
+- "Agents Don't Need More Memory. They Need Better Forgetting."
+- "HTML Is the Most Underrated Agent Output Format"
+- "Your AI Agent Is Failing Because Its Context Is a Junk Drawer"
 
 **Weak titles** are vague announcements:
 
 - "Introducing our new metrics product"
 - "Performance improvements in Ylang Labs"
 - "AI-powered debugging with Seer"
+- "Understanding agent memory"
+- "A guide to AI-native software development"
+
+Use these title shapes when drafting:
+
+- **Contrarian thesis:** "`[Common belief]` is not the bottleneck. `[Hidden constraint]` is."
+- **Failure mode:** "Your `[system]` is failing because `[specific cause]`."
+- **Specific payoff:** "How to `[achieve outcome]` without `[costly tradeoff]`."
+- **Technical shift:** "`[Technology]` changes where `[workflow]` can happen."
+- **Build story:** "We built `[thing]`. The hard part was `[surprising constraint]`."
+- **Inside-view deep dive:** "Inside `[system/team/product]`: how `[specific mechanism]` handles `[real constraint]`."
+- **Numbers-first story:** "How `[team/product]` handles `[scale number]` with `[specific architecture or tradeoff]`."
+
+Do not sand the title down into a neutral label. If the strongest title feels too bold, make the post prove it.
 
 ## The Closing
 
@@ -255,7 +304,8 @@ Run through both checklists:
 - Examples are useful and limited, not a catalog of everything that could happen
 - Headings convey information
 - Right length: 5 minutes or less by default, unless the user explicitly allowed a longer post
-- Title is specific and compelling
+- Title is specific, ambitious, and still defensible
+- Summary and TLDR sell the strongest useful takeaway, not just the topic
 
 **Final Check:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,10 @@ Blog asset standards:
 Blog writing standards:
 
 - The publication focuses on AI engineering, agents, LLM systems, RAG, evaluation, ML infrastructure, and practical implementation lessons.
+- The default blog writing standard is The Pragmatic Engineer by Gergely Orosz. Use it as the editorial reference for inside-view engineering writing: practical, source-backed, numbers-forward, specific about how teams and systems work, and useful to engineers and engineering leaders. Do not imitate Gergely Orosz's exact prose, recurring phrasing, or author persona.
+- Default to a Pragmatic Engineer-inspired voice: direct, concrete, technically sharp, and written by someone who has shipped the work and understands the failure modes. Prefer useful judgment, named systems, operational tradeoffs, and industry context over banter, hype, or detached research prose.
+- Be ambitious in the blog body and packaging. Titles, summaries, TLDR bullets, openings, and social posts should sell the strongest defensible thesis, tension, payoff, or shift in the article instead of merely naming the topic.
+- Ambition must remain evidence-backed. Every bold title, hook, or claim needs support from a mechanism, example, number, tradeoff, caveat, source, or implementation detail in the article.
 - Default blog posts to 5 minutes or less unless the user explicitly asks for or approves a longer post. If a topic needs more depth, narrow the scope, split follow-up posts, or confirm the longer format before drafting past the default.
 - Prefer concrete technical explanations, architecture diagrams, examples, and citations over generic marketing prose.
 - Use post-type structures rather than one universal article template:


### PR DESCRIPTION
## Summary

- Made The Pragmatic Engineer by Gergely Orosz the default blog writing and social-copy editorial standard.
- Removed the Ylang Labs prose/voice qualifier from the writing, MDX authoring, publishing workflow, and social-copy guidance.
- Added guidance for inside-view, source-backed, numbers-forward engineering writing with named systems, operational tradeoffs, and business context.
- Strengthened ambitious-but-defensible guidance for titles, openings, summaries, TLDR bullets, and social copy.

## Validation

- git diff --check
- git diff --cached --check before commit/amend
- pre-commit lint-staged ran Prettier on the staged Markdown files during commit/amend

## Notes

- Used https://www.pragmaticengineer.com/ and public newsletter pages as the reference point for high-level editorial traits.
- This sets The Pragmatic Engineer as the default editorial model while avoiding direct imitation of exact prose, phrasing, or author persona.
- Left unrelated untracked Hermes blog and artwork files out of this PR.