### PR TITLE
Harden routes, payloads, and accessibility

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -4,7 +4,7 @@ import Link from '@/components/Link'
 import EmptyView from '@/components/EmptyView'
 import BlogCard from '@/components/BlogCard'
 import ProjectCard from '@/components/ProjectCard'
-import { motion, Variants } from 'framer-motion'
+import { motion, Variants } from 'motion/react'
 import NextLink from 'next/link'
 
 const container: Variants = {
@@ -55,7 +55,7 @@ export default function Home({ posts, projects, hasMorePosts, hasProjects }) {
           <div className="flex flex-col items-center justify-center gap-4 pt-8 sm:flex-row">
             <NextLink
               href="/blogs"
-              className="group relative inline-flex items-center justify-center overflow-hidden rounded-full bg-primary-500 px-8 py-3 font-medium text-white transition-all duration-300 hover:scale-105 hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-200 focus:ring-offset-2"
+              className="group relative inline-flex items-center justify-center overflow-hidden rounded-full bg-primary-500 px-8 py-3 font-medium text-gray-950 transition-[background-color,transform] duration-300 hover:scale-105 hover:bg-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-700 focus-visible:ring-offset-2"
             >
               <span className="mr-2">Start Reading</span>
               <svg

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,9 +1,14 @@
-import { NewsletterAPI } from 'pliny/newsletter'
+import { NewsletterAPI, type NewsletterConfig } from 'pliny/newsletter'
 import siteMetadata from '@/data/siteMetadata'
 
+const provider = siteMetadata.newsletter?.provider
+
+if (!provider) {
+  throw new Error('Newsletter provider is not configured')
+}
+
 const handler = NewsletterAPI({
-  // @ts-ignore
-  provider: siteMetadata.newsletter.provider,
+  provider: provider as NewsletterConfig['provider'],
 })
 
-export { handler as GET, handler as POST }
+export { handler as POST }

--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -2,8 +2,7 @@ import BlogCardLayout from '@/layouts/BlogCardLayout'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import { allBlogs } from 'contentlayer/generated'
 import { genPageMetadata } from 'app/seo'
-
-const POSTS_PER_PAGE = 10
+import { BLOGS_PER_PAGE } from '@/components/lib/pagination'
 
 export const metadata = genPageMetadata({ title: 'Blog', url: '/blogs' })
 
@@ -11,21 +10,10 @@ export default function BlogPage() {
   const publishedPosts = allBlogs.filter((post) => !post.draft)
   const posts = allCoreContent(sortPosts(publishedPosts))
   const pageNumber = 1
-  const initialDisplayPosts = posts.slice(
-    POSTS_PER_PAGE * (pageNumber - 1),
-    POSTS_PER_PAGE * pageNumber
-  )
   const pagination = {
     currentPage: pageNumber,
-    totalPages: Math.ceil(posts.length / POSTS_PER_PAGE),
+    totalPages: Math.ceil(posts.length / BLOGS_PER_PAGE),
   }
 
-  return (
-    <BlogCardLayout
-      posts={posts}
-      initialDisplayPosts={initialDisplayPosts}
-      pagination={pagination}
-      title="All Posts"
-    />
-  )
+  return <BlogCardLayout posts={posts} pagination={pagination} title="All Posts" />
 }

--- a/app/blogs/page/[page]/page.tsx
+++ b/app/blogs/page/[page]/page.tsx
@@ -10,10 +10,11 @@ import { notFound, permanentRedirect } from 'next/navigation'
 import { genPageMetadata } from 'app/seo'
 
 const publishedBlogs = allBlogs.filter((post) => !post.draft)
+const isStaticExport = Boolean(process.env.EXPORT)
 
 export const generateStaticParams = async () => {
   const totalPages = Math.ceil(publishedBlogs.length / BLOGS_PER_PAGE)
-  return getPaginatedStaticParams(totalPages)
+  return getPaginatedStaticParams(totalPages, { includeFirstPage: isStaticExport })
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ page: string }> }) {
@@ -21,7 +22,11 @@ export async function generateMetadata({ params }: { params: Promise<{ page: str
   const totalPages = Math.ceil(publishedBlogs.length / BLOGS_PER_PAGE)
 
   if (page === '1') {
-    return genPageMetadata({ title: 'Blog', url: '/blogs' })
+    return genPageMetadata({
+      title: 'Blog',
+      url: '/blogs',
+      robots: { index: false, follow: true },
+    })
   }
 
   const pageNumber = getValidPageNumber(page, totalPages)
@@ -37,7 +42,7 @@ export async function generateMetadata({ params }: { params: Promise<{ page: str
 export default async function Page({ params }: { params: Promise<{ page: string }> }) {
   const resolvedParams = await params
 
-  if (resolvedParams.page === '1') {
+  if (resolvedParams.page === '1' && !isStaticExport) {
     permanentRedirect('/blogs')
   }
 

--- a/app/blogs/page/[page]/page.tsx
+++ b/app/blogs/page/[page]/page.tsx
@@ -1,44 +1,58 @@
 import BlogCardLayout from '@/layouts/BlogCardLayout'
-import { getValidPageNumber } from '@/components/lib/pagination'
+import {
+  BLOGS_PER_PAGE,
+  getPaginatedStaticParams,
+  getValidPageNumber,
+} from '@/components/lib/pagination'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import { allBlogs } from 'contentlayer/generated'
-import { notFound } from 'next/navigation'
+import { notFound, permanentRedirect } from 'next/navigation'
+import { genPageMetadata } from 'app/seo'
 
-const POSTS_PER_PAGE = 10
 const publishedBlogs = allBlogs.filter((post) => !post.draft)
 
 export const generateStaticParams = async () => {
-  const totalPages = Math.ceil(publishedBlogs.length / POSTS_PER_PAGE)
-  const paths = Array.from({ length: totalPages }, (_, i) => ({ page: (i + 1).toString() }))
+  const totalPages = Math.ceil(publishedBlogs.length / BLOGS_PER_PAGE)
+  return getPaginatedStaticParams(totalPages)
+}
 
-  return paths
+export async function generateMetadata({ params }: { params: Promise<{ page: string }> }) {
+  const { page } = await params
+  const totalPages = Math.ceil(publishedBlogs.length / BLOGS_PER_PAGE)
+
+  if (page === '1') {
+    return genPageMetadata({ title: 'Blog', url: '/blogs' })
+  }
+
+  const pageNumber = getValidPageNumber(page, totalPages)
+  if (!pageNumber) notFound()
+
+  return genPageMetadata({
+    title: `Blog - Page ${pageNumber}`,
+    description: `Page ${pageNumber} of Ylang Labs AI engineering articles.`,
+    url: `/blogs/page/${pageNumber}`,
+  })
 }
 
 export default async function Page({ params }: { params: Promise<{ page: string }> }) {
   const resolvedParams = await params
+
+  if (resolvedParams.page === '1') {
+    permanentRedirect('/blogs')
+  }
+
   const posts = allCoreContent(sortPosts(publishedBlogs))
-  const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE)
+  const totalPages = Math.ceil(posts.length / BLOGS_PER_PAGE)
   const pageNumber = getValidPageNumber(resolvedParams.page, totalPages)
 
   if (!pageNumber) {
     notFound()
   }
 
-  const initialDisplayPosts = posts.slice(
-    POSTS_PER_PAGE * (pageNumber - 1),
-    POSTS_PER_PAGE * pageNumber
-  )
   const pagination = {
     currentPage: pageNumber,
     totalPages,
   }
 
-  return (
-    <BlogCardLayout
-      posts={posts}
-      initialDisplayPosts={initialDisplayPosts}
-      pagination={pagination}
-      title="All Posts"
-    />
-  )
+  return <BlogCardLayout posts={posts} pagination={pagination} title="All Posts" />
 }

--- a/app/contact-us/layout.tsx
+++ b/app/contact-us/layout.tsx
@@ -1,0 +1,11 @@
+import { genPageMetadata } from 'app/seo'
+
+export const metadata = genPageMetadata({
+  title: 'Contact Us',
+  description: 'Contact Ylang Labs about AI engineering projects, research, and support.',
+  url: '/contact-us',
+})
+
+export default function ContactLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/app/contact-us/page.tsx
+++ b/app/contact-us/page.tsx
@@ -123,7 +123,7 @@ export default function ContactPage() {
               <div className="mt-12 space-y-6">
                 <div className="flex items-center gap-4 rounded-lg bg-white/10 p-4 backdrop-blur-sm">
                   <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/20">
-                    <MdEmail className="h-6 w-6" />
+                    <MdEmail className="h-6 w-6" aria-hidden="true" />
                   </div>
                   <div>
                     <p className="text-sm font-medium text-white/70">Email us</p>
@@ -186,6 +186,7 @@ export default function ContactPage() {
                         </FormLabel>
                         <FormControl>
                           <Input
+                            autoComplete="given-name"
                             placeholder="What should we call you?"
                             {...field}
                             className={INPUT_STYLES}
@@ -205,6 +206,7 @@ export default function ContactPage() {
                         </FormLabel>
                         <FormControl>
                           <Input
+                            autoComplete="family-name"
                             placeholder="And your family name?"
                             {...field}
                             className={INPUT_STYLES}
@@ -229,6 +231,8 @@ export default function ContactPage() {
                         <FormControl>
                           <Input
                             type="email"
+                            autoComplete="email"
+                            spellCheck={false}
                             placeholder="your.email@example.com"
                             {...field}
                             className={INPUT_STYLES}
@@ -249,6 +253,7 @@ export default function ContactPage() {
                         <FormControl>
                           <PhoneInput
                             defaultCountry="PH"
+                            autoComplete="tel"
                             placeholder="Your phone number"
                             {...field}
                             className={INPUT_STYLES}
@@ -313,7 +318,8 @@ export default function ContactPage() {
                       </FormLabel>
                       <FormControl>
                         <Textarea
-                          placeholder="Please tell us how we can help you..."
+                          autoComplete="off"
+                          placeholder="Please tell us how we can help you…"
                           {...field}
                           className="min-h-[120px] rounded-lg border-gray-200 bg-gray-50 transition-all duration-200 focus:border-primary-500 focus:bg-white focus:ring-1 focus:ring-primary-500/20 dark:border-gray-700 dark:bg-gray-800 dark:focus:border-primary-400 dark:focus:bg-gray-900"
                         />
@@ -328,11 +334,12 @@ export default function ContactPage() {
                   <Button
                     type="submit"
                     size="lg"
-                    className="h-11 w-full rounded-lg bg-primary-500 font-medium text-white shadow-lg transition-all duration-200 hover:bg-primary-600 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+                    className="h-11 w-full rounded-lg bg-primary-500 font-medium text-gray-950 shadow-lg transition-[background-color,box-shadow] duration-200 hover:bg-primary-600 focus:ring-2 focus:ring-primary-700 focus:ring-offset-2"
                     disabled={form.formState.isSubmitting}
+                    aria-busy={form.formState.isSubmitting}
                   >
                     {form.formState.isSubmitting ? (
-                      <InlineLoader text="Sending your message..." size={20} />
+                      <InlineLoader text="Sending your message…" size={20} color="text-gray-950" />
                     ) : (
                       'Send Message'
                     )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,8 @@
 import 'css/tailwind.css'
-import 'pliny/search/algolia.css'
 import 'remark-github-blockquote-alert/alert.css'
 
 import { Analytics, AnalyticsConfig } from 'pliny/analytics'
-import { SearchProvider, SearchConfig } from 'pliny/search'
+import { KBarSearchProvider } from 'pliny/search/KBar'
 import { Toaster } from '@/components/ui/toaster'
 import Header from '@/components/Header'
 import SectionContainer from '@/components/SectionContainer'
@@ -12,6 +11,16 @@ import siteMetadata from '@/data/siteMetadata'
 import { ThemeProviders } from './theme-providers'
 import { Metadata } from 'next'
 import type { CSSProperties } from 'react'
+
+function getKbarConfig() {
+  const search = siteMetadata.search
+  if (search?.provider !== 'kbar' || !search.kbarConfig) {
+    throw new Error('Ylang Labs requires the KBar search provider')
+  }
+  return search.kbarConfig
+}
+
+const kbarConfig = getKbarConfig()
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteMetadata.siteUrl),
@@ -57,7 +66,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const basePath = process.env.BASE_PATH || ''
 
   return (
-    <html lang={siteMetadata.language} className={'scroll-smooth'} suppressHydrationWarning>
+    <html
+      lang={siteMetadata.language}
+      className="scroll-smooth motion-reduce:scroll-auto"
+      suppressHydrationWarning
+    >
       <link
         rel="apple-touch-icon"
         sizes="180x180"
@@ -82,7 +95,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ThemeProviders>
           <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
           <SectionContainer>
-            <SearchProvider searchConfig={siteMetadata.search as SearchConfig}>
+            <KBarSearchProvider kbarConfig={kbarConfig}>
               <a
                 href="#main-content"
                 className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-full focus:bg-primary-500 focus:px-4 focus:py-3 focus:text-sm focus:font-semibold focus:text-gray-950 focus:outline-none focus:ring-2 focus:ring-primary-700 focus:ring-offset-2 dark:focus:ring-primary-300 dark:focus:ring-offset-gray-950"
@@ -94,7 +107,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 {children}
               </main>
               <Toaster />
-            </SearchProvider>
+            </KBarSearchProvider>
           </SectionContainer>
           <Footer />
         </ThemeProviders>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -12,10 +12,12 @@ export default function NotFound() {
         <p className="mb-4 text-xl font-bold leading-normal md:text-2xl">
           Sorry we couldn't find this page.
         </p>
-        <p className="mb-8">But dont worry, you can find plenty of other things on our homepage.</p>
+        <p className="mb-8">
+          But don&apos;t worry, you can find plenty of other things on our homepage.
+        </p>
         <Link
           href="/"
-          className="focus:shadow-outline-blue inline rounded-lg border border-transparent bg-primary-500 px-4 py-2 text-sm font-medium leading-5 text-white shadow transition-colors duration-150 hover:bg-primary-700 focus:outline-none dark:hover:bg-primary-400"
+          className="inline rounded-lg border border-transparent bg-primary-500 px-4 py-2 text-sm font-medium leading-5 text-gray-950 shadow transition-colors duration-150 hover:bg-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-700 focus-visible:ring-offset-2 dark:hover:bg-primary-400"
         >
           Back to homepage
         </Link>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -2,8 +2,7 @@ import ProjectListLayout from '@/layouts/ProjectListLayout'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import { allProjects } from 'contentlayer/generated'
 import { genPageMetadata } from 'app/seo'
-
-const PROJECTS_PER_PAGE = 6
+import { PROJECTS_PER_PAGE } from '@/components/lib/pagination'
 
 export const metadata = genPageMetadata({ title: 'Projects', url: '/projects' })
 
@@ -11,21 +10,10 @@ export default function ProjectsPage() {
   const publishedProjects = allProjects.filter((project) => !project.draft)
   const projects = allCoreContent(sortPosts(publishedProjects))
   const pageNumber = 1
-  const initialDisplayProjects = projects.slice(
-    PROJECTS_PER_PAGE * (pageNumber - 1),
-    PROJECTS_PER_PAGE * pageNumber
-  )
   const pagination = {
     currentPage: pageNumber,
     totalPages: Math.ceil(projects.length / PROJECTS_PER_PAGE),
   }
 
-  return (
-    <ProjectListLayout
-      projects={projects}
-      initialDisplayProjects={initialDisplayProjects}
-      pagination={pagination}
-      title="All Projects"
-    />
-  )
+  return <ProjectListLayout projects={projects} pagination={pagination} title="All Projects" />
 }

--- a/app/projects/page/[page]/page.tsx
+++ b/app/projects/page/[page]/page.tsx
@@ -1,21 +1,46 @@
 import ProjectListLayout from '@/layouts/ProjectListLayout'
-import { getValidPageNumber } from '@/components/lib/pagination'
+import {
+  getPaginatedStaticParams,
+  getValidPageNumber,
+  PROJECTS_PER_PAGE,
+} from '@/components/lib/pagination'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import { allProjects } from 'contentlayer/generated'
-import { notFound } from 'next/navigation'
+import { notFound, permanentRedirect } from 'next/navigation'
+import { genPageMetadata } from 'app/seo'
 
-const PROJECTS_PER_PAGE = 6
 const publishedProjects = allProjects.filter((project) => !project.draft)
 
 export const generateStaticParams = async () => {
   const totalPages = Math.ceil(publishedProjects.length / PROJECTS_PER_PAGE)
-  const paths = Array.from({ length: totalPages }, (_, i) => ({ page: (i + 1).toString() }))
+  return getPaginatedStaticParams(totalPages)
+}
 
-  return paths
+export async function generateMetadata({ params }: { params: Promise<{ page: string }> }) {
+  const { page } = await params
+  const totalPages = Math.ceil(publishedProjects.length / PROJECTS_PER_PAGE)
+
+  if (page === '1') {
+    return genPageMetadata({ title: 'Projects', url: '/projects' })
+  }
+
+  const pageNumber = getValidPageNumber(page, totalPages)
+  if (!pageNumber) notFound()
+
+  return genPageMetadata({
+    title: `Projects - Page ${pageNumber}`,
+    description: `Page ${pageNumber} of Ylang Labs AI engineering projects.`,
+    url: `/projects/page/${pageNumber}`,
+  })
 }
 
 export default async function Page({ params }: { params: Promise<{ page: string }> }) {
   const resolvedParams = await params
+
+  if (resolvedParams.page === '1') {
+    permanentRedirect('/projects')
+  }
+
   const projects = allCoreContent(sortPosts(publishedProjects))
   const totalPages = Math.ceil(projects.length / PROJECTS_PER_PAGE)
   const pageNumber = getValidPageNumber(resolvedParams.page, totalPages)
@@ -24,21 +49,10 @@ export default async function Page({ params }: { params: Promise<{ page: string 
     notFound()
   }
 
-  const initialDisplayProjects = projects.slice(
-    PROJECTS_PER_PAGE * (pageNumber - 1),
-    PROJECTS_PER_PAGE * pageNumber
-  )
   const pagination = {
     currentPage: pageNumber,
     totalPages,
   }
 
-  return (
-    <ProjectListLayout
-      projects={projects}
-      initialDisplayProjects={initialDisplayProjects}
-      pagination={pagination}
-      title="All Projects"
-    />
-  )
+  return <ProjectListLayout projects={projects} pagination={pagination} title="All Projects" />
 }

--- a/app/projects/page/[page]/page.tsx
+++ b/app/projects/page/[page]/page.tsx
@@ -10,10 +10,11 @@ import { notFound, permanentRedirect } from 'next/navigation'
 import { genPageMetadata } from 'app/seo'
 
 const publishedProjects = allProjects.filter((project) => !project.draft)
+const isStaticExport = Boolean(process.env.EXPORT)
 
 export const generateStaticParams = async () => {
   const totalPages = Math.ceil(publishedProjects.length / PROJECTS_PER_PAGE)
-  return getPaginatedStaticParams(totalPages)
+  return getPaginatedStaticParams(totalPages, { includeFirstPage: isStaticExport })
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ page: string }> }) {
@@ -21,7 +22,11 @@ export async function generateMetadata({ params }: { params: Promise<{ page: str
   const totalPages = Math.ceil(publishedProjects.length / PROJECTS_PER_PAGE)
 
   if (page === '1') {
-    return genPageMetadata({ title: 'Projects', url: '/projects' })
+    return genPageMetadata({
+      title: 'Projects',
+      url: '/projects',
+      robots: { index: false, follow: true },
+    })
   }
 
   const pageNumber = getValidPageNumber(page, totalPages)
@@ -37,7 +42,7 @@ export async function generateMetadata({ params }: { params: Promise<{ page: str
 export default async function Page({ params }: { params: Promise<{ page: string }> }) {
   const resolvedParams = await params
 
-  if (resolvedParams.page === '1') {
+  if (resolvedParams.page === '1' && !isStaticExport) {
     permanentRedirect('/projects')
   }
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,8 @@
 import { MetadataRoute } from 'next'
 import siteMetadata from '@/data/siteMetadata'
 
+export const dynamic = 'force-static'
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,6 +2,8 @@ import { MetadataRoute } from 'next'
 import { allBlogs, allProjects } from 'contentlayer/generated'
 import siteMetadata from '@/data/siteMetadata'
 
+export const dynamic = 'force-static'
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const siteUrl = siteMetadata.siteUrl
 

--- a/app/theme-providers.tsx
+++ b/app/theme-providers.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import { ThemeProvider } from 'next-themes'
+import { MotionConfig } from 'motion/react'
 import siteMetadata from '@/data/siteMetadata'
 
 export function ThemeProviders({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme={siteMetadata.theme} enableSystem>
-      {children}
-    </ThemeProvider>
+    <MotionConfig reducedMotion="user">
+      <ThemeProvider attribute="class" defaultTheme={siteMetadata.theme} enableSystem>
+        {children}
+      </ThemeProvider>
+    </MotionConfig>
   )
 }

--- a/components/CardTag.tsx
+++ b/components/CardTag.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 const Tag = ({ text }: Props) => {
   return (
-    <span className="inline-block rounded-sm bg-secondary-500 px-2 py-1 text-xs font-medium text-white">
+    <span className="inline-block rounded-sm bg-secondary-600 px-2 py-1 text-xs font-medium text-white">
       {text}
     </span>
   )

--- a/components/InlineLoader.tsx
+++ b/components/InlineLoader.tsx
@@ -20,7 +20,7 @@ interface InlineLoaderProps {
 }
 
 export const InlineLoader: React.FC<InlineLoaderProps> = ({
-  text = 'Loading...',
+  text = 'Loading…',
   size = 20,
   color = 'text-white',
   className = '',
@@ -30,28 +30,37 @@ export const InlineLoader: React.FC<InlineLoaderProps> = ({
   const colorStyle = !color.startsWith('text-') ? { color } : {}
 
   return (
-    <span className={`flex items-center justify-center ${className}`}>
-      <svg
-        className={`-ml-1 mr-3 animate-spin ${colorClass}`}
+    <span
+      className={`flex items-center justify-center ${className}`}
+      role="status"
+      aria-live="polite"
+    >
+      <span
+        aria-hidden="true"
+        className={`-ml-1 mr-3 animate-spin motion-reduce:animate-none ${colorClass}`}
         style={{ height: size, width: size, ...colorStyle }}
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
       >
-        <circle
-          className="opacity-25"
-          cx="12"
-          cy="12"
-          r="10"
-          stroke="currentColor"
-          strokeWidth="4"
-        ></circle>
-        <path
-          className="opacity-75"
-          fill="currentColor"
-          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-        ></path>
-      </svg>
+        <svg
+          className="h-full w-full"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          ></circle>
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          ></path>
+        </svg>
+      </span>
       {text && <span>{text}</span>}
     </span>
   )

--- a/components/PhoneInput.tsx
+++ b/components/PhoneInput.tsx
@@ -80,6 +80,9 @@ const CountrySelect = ({
           variant="outline"
           className="flex gap-1 rounded-e-none rounded-s-lg border-r-0 px-3 focus:z-10"
           disabled={disabled}
+          aria-label={
+            selectedCountry ? `Change country, ${selectedCountry}` : 'Select phone country'
+          }
         >
           <FlagComponent country={selectedCountry} countryName={selectedCountry} />
           <ChevronsUpDown
@@ -87,7 +90,7 @@ const CountrySelect = ({
           />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[300px] bg-white p-0">
+      <PopoverContent className="w-[300px] bg-popover p-0 text-popover-foreground">
         <Command>
           <CommandInput placeholder="Search country..." />
           <CommandList>
@@ -126,7 +129,7 @@ const CountrySelectOption = ({
   onChange,
 }: CountrySelectOptionProps) => {
   return (
-    <CommandItem className="gap-2 bg-white" onSelect={() => onChange(country)}>
+    <CommandItem className="gap-2" onSelect={() => onChange(country)}>
       <FlagComponent country={country} countryName={countryName} />
       <span className="flex-1 text-sm">{countryName}</span>
       <span className="text-sm text-foreground/50">{`+${RPNInput.getCountryCallingCode(country)}`}</span>

--- a/components/SearchButton.tsx
+++ b/components/SearchButton.tsx
@@ -1,17 +1,10 @@
-import { AlgoliaButton } from 'pliny/search/AlgoliaButton'
 import { KBarButton } from 'pliny/search/KBarButton'
 import siteMetadata from '@/data/siteMetadata'
 
 const SearchButton = ({ mobile = false }: { mobile?: boolean }) => {
-  if (
-    siteMetadata.search &&
-    (siteMetadata.search.provider === 'algolia' || siteMetadata.search.provider === 'kbar')
-  ) {
-    const SearchButtonWrapper =
-      siteMetadata.search.provider === 'algolia' ? AlgoliaButton : KBarButton
-
+  if (siteMetadata.search?.provider === 'kbar') {
     return (
-      <SearchButtonWrapper
+      <KBarButton
         aria-label="Search"
         className={
           mobile
@@ -37,7 +30,7 @@ const SearchButton = ({ mobile = false }: { mobile?: boolean }) => {
         {mobile && (
           <span className="text-sm font-medium text-gray-900 dark:text-gray-100">Search</span>
         )}
-      </SearchButtonWrapper>
+      </KBarButton>
     )
   }
 }

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useEffect, useState } from 'react'
 import { useTheme } from 'next-themes'
-import { Menu, RadioGroup, Transition } from '@headlessui/react'
+import { Menu, Transition } from '@headlessui/react'
 
 const Sun = () => (
   <svg
@@ -10,6 +10,7 @@ const Sun = () => (
     viewBox="0 0 20 20"
     fill="currentColor"
     className="group:hover:text-gray-100 h-6 w-6"
+    aria-hidden="true"
   >
     <path
       fillRule="evenodd"
@@ -24,6 +25,7 @@ const Moon = () => (
     viewBox="0 0 20 20"
     fill="currentColor"
     className="group:hover:text-gray-100 h-6 w-6"
+    aria-hidden="true"
   >
     <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
   </svg>
@@ -38,6 +40,7 @@ const Monitor = () => (
     strokeLinecap="round"
     strokeLinejoin="round"
     className="group:hover:text-gray-100 h-6 w-6"
+    aria-hidden="true"
   >
     <rect x="3" y="3" width="14" height="10" rx="2" ry="2"></rect>
     <line x1="7" y1="17" x2="13" y2="17"></line>
@@ -45,6 +48,12 @@ const Monitor = () => (
   </svg>
 )
 const Blank = () => <svg className="h-6 w-6" />
+
+const themeOptions = [
+  { value: 'light', label: 'Light', Icon: Sun },
+  { value: 'dark', label: 'Dark', Icon: Moon },
+  { value: 'system', label: 'System', Icon: Monitor },
+]
 
 const ThemeSwitch = ({ mobile = false }: { mobile?: boolean }) => {
   const [mounted, setMounted] = useState(false)
@@ -91,58 +100,29 @@ const ThemeSwitch = ({ mobile = false }: { mobile?: boolean }) => {
           leaveTo="transform opacity-0 scale-95"
         >
           <Menu.Items className={dropdownClasses}>
-            <RadioGroup value={theme} onChange={setTheme}>
-              <div className="p-1">
-                <RadioGroup.Option value="light">
-                  <Menu.Item>
-                    {({ active }) => (
-                      <button
-                        className={`${
-                          active ? 'bg-primary-600 text-white' : ''
-                        } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
-                      >
-                        <div className="mr-2">
-                          <Sun />
-                        </div>
-                        Light
-                      </button>
-                    )}
-                  </Menu.Item>
-                </RadioGroup.Option>
-                <RadioGroup.Option value="dark">
-                  <Menu.Item>
-                    {({ active }) => (
-                      <button
-                        className={`${
-                          active ? 'bg-primary-600 text-white' : ''
-                        } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
-                      >
-                        <div className="mr-2">
-                          <Moon />
-                        </div>
-                        Dark
-                      </button>
-                    )}
-                  </Menu.Item>
-                </RadioGroup.Option>
-                <RadioGroup.Option value="system">
-                  <Menu.Item>
-                    {({ active }) => (
-                      <button
-                        className={`${
-                          active ? 'bg-primary-600 text-white' : ''
-                        } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
-                      >
-                        <div className="mr-2">
-                          <Monitor />
-                        </div>
-                        System
-                      </button>
-                    )}
-                  </Menu.Item>
-                </RadioGroup.Option>
-              </div>
-            </RadioGroup>
+            <div className="p-1">
+              {themeOptions.map(({ value, label, Icon }) => (
+                <Menu.Item key={value}>
+                  {({ active }) => (
+                    <button
+                      type="button"
+                      onClick={() => setTheme(value)}
+                      aria-current={theme === value ? 'true' : undefined}
+                      className={`${
+                        active || theme === value
+                          ? 'bg-primary-600 text-white'
+                          : 'text-gray-900 dark:text-gray-100'
+                      } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
+                    >
+                      <span className="mr-2">
+                        <Icon />
+                      </span>
+                      {label}
+                    </button>
+                  )}
+                </Menu.Item>
+              ))}
+            </div>
           </Menu.Items>
         </Transition>
       </Menu>

--- a/components/blogs/context-engineering-for-ai-agents/ProcessFlow.tsx
+++ b/components/blogs/context-engineering-for-ai-agents/ProcessFlow.tsx
@@ -24,14 +24,19 @@ const ProcessFlow = () => {
   const [step, setStep] = useState(0)
 
   useEffect(() => {
-    let timer: any
-    if (isRunning) {
-      timer = setInterval(() => {
-        setStep((prev) => (prev < 8 ? prev + 1 : prev))
-      }, 800)
+    if (!isRunning) return
+
+    if (step >= 8) {
+      setIsRunning(false)
+      return
     }
-    return () => clearInterval(timer)
-  }, [isRunning])
+
+    const timer = setTimeout(() => {
+      setStep((previousStep) => previousStep + 1)
+    }, 800)
+
+    return () => clearTimeout(timer)
+  }, [isRunning, step])
 
   const reset = () => {
     setIsRunning(false)

--- a/components/lib/pagination.ts
+++ b/components/lib/pagination.ts
@@ -12,8 +12,12 @@ export function getValidPageNumber(page: string, totalPages: number) {
   return pageNumber
 }
 
-export function getPaginatedStaticParams(totalPages: number) {
-  return Array.from({ length: Math.max(totalPages - 1, 0) }, (_, index) => ({
-    page: String(index + 2),
+export function getPaginatedStaticParams(
+  totalPages: number,
+  { includeFirstPage = false }: { includeFirstPage?: boolean } = {}
+) {
+  const firstPage = includeFirstPage ? 1 : 2
+  return Array.from({ length: Math.max(totalPages - firstPage + 1, 0) }, (_, index) => ({
+    page: String(index + firstPage),
   }))
 }

--- a/components/lib/pagination.ts
+++ b/components/lib/pagination.ts
@@ -1,3 +1,6 @@
+export const BLOGS_PER_PAGE = 10
+export const PROJECTS_PER_PAGE = 6
+
 export function getValidPageNumber(page: string, totalPages: number) {
   if (!/^[1-9]\d*$/.test(page)) return null
 
@@ -7,4 +10,10 @@ export function getValidPageNumber(page: string, totalPages: number) {
   }
 
   return pageNumber
+}
+
+export function getPaginatedStaticParams(totalPages: number) {
+  return Array.from({ length: Math.max(totalPages - 1, 0) }, (_, index) => ({
+    page: String(index + 2),
+  }))
 }

--- a/components/ui/resizable-navbar.tsx
+++ b/components/ui/resizable-navbar.tsx
@@ -47,7 +47,7 @@ interface MobileNavMenuProps {
 }
 
 export const Navbar = ({ children, className }: NavbarProps) => {
-  const ref = useRef<HTMLDivElement>(null)
+  const ref = useRef<HTMLElement>(null)
   const { scrollY } = useScroll({
     target: ref,
     offset: ['start start', 'end start'],
@@ -73,25 +73,27 @@ export const Navbar = ({ children, className }: NavbarProps) => {
   })
 
   return (
-    <motion.div
+    <motion.header
       ref={ref}
       // IMPORTANT: Change this to class of `fixed` if you want the navbar to be fixed
       className={cn('sticky inset-x-0 top-20 z-20 w-full', className)}
       animate={{ y: hidden ? '-120%' : '0%' }}
       transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+      onFocusCapture={() => setHidden(false)}
     >
       {React.Children.map(children, (child) =>
         React.isValidElement(child)
           ? React.cloneElement(child as React.ReactElement<{ visible?: boolean }>, { visible })
           : child
       )}
-    </motion.div>
+    </motion.header>
   )
 }
 
 export const NavBody = ({ children, className, visible }: NavBodyProps) => {
   return (
-    <motion.div
+    <motion.nav
+      aria-label="Primary navigation"
       animate={{
         backdropFilter: visible ? 'blur(10px)' : 'none',
         boxShadow: visible
@@ -115,7 +117,7 @@ export const NavBody = ({ children, className, visible }: NavBodyProps) => {
       )}
     >
       {children}
-    </motion.div>
+    </motion.nav>
   )
 }
 
@@ -153,7 +155,8 @@ export const NavItems = ({ items, className, onItemClick }: NavItemsProps) => {
 
 export const MobileNav = ({ children, className, visible }: MobileNavProps) => {
   return (
-    <motion.div
+    <motion.nav
+      aria-label="Primary navigation"
       animate={{
         backdropFilter: visible ? 'blur(10px)' : 'none',
         boxShadow: visible
@@ -177,7 +180,7 @@ export const MobileNav = ({ children, className, visible }: MobileNavProps) => {
       )}
     >
       {children}
-    </motion.div>
+    </motion.nav>
   )
 }
 

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -96,7 +96,8 @@ input:-webkit-autofill:focus {
 }
 
 .content-header:hover .content-header-link,
-.content-header-link:hover {
+.content-header-link:hover,
+.content-header-link:focus-visible {
   opacity: 1;
 }
 
@@ -113,4 +114,10 @@ input:-webkit-autofill:focus {
 .flow-line {
   stroke-dasharray: 10, 10;
   animation: flow 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flow-line {
+    animation: none;
+  }
 }

--- a/layouts/BlogCardLayout.tsx
+++ b/layouts/BlogCardLayout.tsx
@@ -10,6 +10,7 @@ import siteMetadata from '@/data/siteMetadata'
 import EmptyView from '@/components/EmptyView'
 import BlogPagination from '@/layouts/components/BlogPagination'
 import CardTag from '@/components/CardTag'
+import { BLOGS_PER_PAGE } from '@/components/lib/pagination'
 
 interface PaginationProps {
   totalPages: number
@@ -19,7 +20,6 @@ interface PaginationProps {
 interface BlogCardLayoutProps {
   posts: CoreContent<Blog>[]
   title: string
-  initialDisplayPosts?: CoreContent<Blog>[]
   pagination?: PaginationProps
   description?: string
 }
@@ -39,7 +39,6 @@ function getDisplayImage(post: CoreContent<Blog>) {
 export default function BlogCardLayout({
   posts,
   title,
-  initialDisplayPosts = [],
   pagination,
   description = 'Latest Blogs from Ylang Labs',
 }: BlogCardLayoutProps) {
@@ -55,8 +54,11 @@ export default function BlogCardLayout({
     })
   }, [posts, searchValue])
 
-  const displayPosts =
-    initialDisplayPosts.length > 0 && !searchValue ? initialDisplayPosts : filteredBlogPosts
+  const currentPage = pagination?.currentPage ?? 1
+  const pageStart = BLOGS_PER_PAGE * (currentPage - 1)
+  const displayPosts = searchValue
+    ? filteredBlogPosts
+    : filteredBlogPosts.slice(pageStart, pageStart + BLOGS_PER_PAGE)
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 pb-24 pt-12 sm:px-6 lg:px-0">

--- a/layouts/BlogGridLayout.tsx
+++ b/layouts/BlogGridLayout.tsx
@@ -5,7 +5,7 @@ import { CoreContent } from 'pliny/utils/contentlayer'
 import type { Blog } from 'contentlayer/generated'
 import BlogCard from '@/components/BlogCard'
 import EmptyView from '@/components/EmptyView'
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 import BlogPagination from '@/layouts/components/BlogPagination'
 
 interface PaginationProps {

--- a/layouts/ProjectListLayout.tsx
+++ b/layouts/ProjectListLayout.tsx
@@ -8,7 +8,8 @@ import { allAuthors } from 'contentlayer/generated'
 import Link from '@/components/Link'
 import EmptyView from '@/components/EmptyView'
 import Image from '@/components/Image'
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
+import { PROJECTS_PER_PAGE } from '@/components/lib/pagination'
 
 interface PaginationProps {
   totalPages: number
@@ -17,7 +18,6 @@ interface PaginationProps {
 interface ProjectListLayoutProps {
   projects: CoreContent<Project>[]
   title: string
-  initialDisplayProjects?: CoreContent<Project>[]
   pagination?: PaginationProps
 }
 
@@ -136,12 +136,7 @@ function Pagination({ totalPages, currentPage }: PaginationProps) {
   )
 }
 
-export default function ProjectListLayout({
-  projects,
-  title,
-  initialDisplayProjects = [],
-  pagination,
-}: ProjectListLayoutProps) {
+export default function ProjectListLayout({ projects, title, pagination }: ProjectListLayoutProps) {
   const [searchValue, setSearchValue] = useState('')
 
   const filteredProjects = projects.filter((project) => {
@@ -149,9 +144,11 @@ export default function ProjectListLayout({
     return searchContent.toLowerCase().includes(searchValue.toLowerCase())
   })
 
-  // If initialDisplayProjects exist, display it if no searchValue is specified
-  const displayProjects =
-    initialDisplayProjects.length > 0 && !searchValue ? initialDisplayProjects : filteredProjects
+  const currentPage = pagination?.currentPage ?? 1
+  const pageStart = PROJECTS_PER_PAGE * (currentPage - 1)
+  const displayProjects = searchValue
+    ? filteredProjects
+    : filteredProjects.slice(pageStart, pageStart + PROJECTS_PER_PAGE)
 
   // Function to get author name from slug
   const getAuthorName = (authorSlug: string) => {

--- a/tests/app/api/newsletter/route.test.ts
+++ b/tests/app/api/newsletter/route.test.ts
@@ -1,0 +1,19 @@
+jest.mock('pliny/newsletter', () => ({
+  NewsletterAPI: jest.fn(() => jest.fn()),
+}))
+
+jest.mock('@/data/siteMetadata', () => ({
+  __esModule: true,
+  default: {
+    newsletter: { provider: 'mailchimp' },
+  },
+}))
+
+import * as newsletterRoute from '@/app/api/newsletter/route'
+
+describe('newsletter route', () => {
+  it('exposes subscription as POST only', () => {
+    expect(newsletterRoute.POST).toEqual(expect.any(Function))
+    expect(newsletterRoute).not.toHaveProperty('GET')
+  })
+})

--- a/tests/components/ThemeSwitch.test.tsx
+++ b/tests/components/ThemeSwitch.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import ThemeSwitch from '@/components/ThemeSwitch'
+
+const setTheme = jest.fn()
+
+jest.mock('next-themes', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    resolvedTheme: 'light',
+    setTheme,
+  }),
+}))
+
+describe('ThemeSwitch', () => {
+  it('uses one keyboard-operable menu item per theme', async () => {
+    render(<ThemeSwitch />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Theme switcher' }))
+
+    const lightOption = await screen.findByRole('menuitem', { name: /light/i })
+    expect(lightOption.querySelector('button')).toBeNull()
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /dark/i }))
+    await waitFor(() => expect(setTheme).toHaveBeenCalledWith('dark'))
+  })
+})

--- a/tests/components/blogs/ProcessFlow.test.tsx
+++ b/tests/components/blogs/ProcessFlow.test.tsx
@@ -1,0 +1,39 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+
+import ProcessFlow from '@/components/blogs/context-engineering-for-ai-agents/ProcessFlow'
+
+jest.mock('lucide-react', () => ({
+  Activity: () => null,
+  ArrowRight: () => null,
+  Clock: () => null,
+  Play: () => null,
+  RotateCcw: () => null,
+  ShieldCheck: () => null,
+}))
+
+describe('ProcessFlow', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  it('stops scheduling work when the simulation completes', () => {
+    render(<ProcessFlow />)
+
+    const runButton = screen.getByRole('button', { name: /run simulation/i })
+    fireEvent.click(runButton)
+
+    for (let step = 0; step < 7; step += 1) {
+      act(() => {
+        jest.advanceTimersByTime(800)
+      })
+    }
+
+    expect(runButton).toBeEnabled()
+    expect(jest.getTimerCount()).toBe(0)
+  })
+})

--- a/tests/components/lib/pagination.test.ts
+++ b/tests/components/lib/pagination.test.ts
@@ -1,4 +1,4 @@
-import { getValidPageNumber } from '@/components/lib/pagination'
+import { getPaginatedStaticParams, getValidPageNumber } from '@/components/lib/pagination'
 
 describe('getValidPageNumber', () => {
   it('accepts pages inside the available range', () => {
@@ -15,5 +15,10 @@ describe('getValidPageNumber', () => {
   it('rejects pages outside the available range', () => {
     expect(getValidPageNumber('0', 3)).toBeNull()
     expect(getValidPageNumber('4', 3)).toBeNull()
+  })
+
+  it('generates only canonical paginated routes after the index page', () => {
+    expect(getPaginatedStaticParams(1)).toEqual([])
+    expect(getPaginatedStaticParams(3)).toEqual([{ page: '2' }, { page: '3' }])
   })
 })

--- a/tests/components/lib/pagination.test.ts
+++ b/tests/components/lib/pagination.test.ts
@@ -21,4 +21,12 @@ describe('getValidPageNumber', () => {
     expect(getPaginatedStaticParams(1)).toEqual([])
     expect(getPaginatedStaticParams(3)).toEqual([{ page: '2' }, { page: '3' }])
   })
+
+  it('includes page one when a static export needs a concrete legacy path', () => {
+    expect(getPaginatedStaticParams(3, { includeFirstPage: true })).toEqual([
+      { page: '1' },
+      { page: '2' },
+      { page: '3' },
+    ])
+  })
 })


### PR DESCRIPTION
## What changed

- make newsletter subscriptions POST-only and fail clearly when the provider is missing
- remove duplicate `/blogs/page/1` and `/projects/page/1` static routes, permanently redirect those legacy URLs, and add page-specific canonicals
- give `/contact-us` its own metadata and canonical URL
- avoid serializing paginated listing slices twice and load only the configured KBar search provider
- fix the completed process simulation so it stops scheduling timers
- replace nested theme controls with keyboard-operable menu items
- add navigation landmarks, reduced-motion behavior, dark-mode phone-selector tokens, form autocomplete, and accessible contrast
- add focused regression tests for pagination, newsletter methods, theme selection, and timer cleanup

## Why

The audit found broken route semantics, duplicate crawlable URLs, unnecessary client payloads, a timer that kept running after completion, and several accessibility regressions. These changes keep the fixes scoped to confirmed behavior and preserve the existing content architecture.

## Validation

- `pnpm lint` (0 errors; 2 pre-existing unused-disable warnings)
- `pnpm test:unit` (10 suites, 19 tests)
- `NEXT_PUBLIC_WEB3_FORMS_ACCESS_KEY=test-key pnpm build`
- production smoke checks: newsletter GET returns 405; `/blogs/page/1` returns 308; contact/blog/project canonicals match their routes

## Follow-up opportunities

- split the global MDX component registry so unrelated React Flow, Recharts, and interactive diagram code is not referenced by every article route
- lazy-render below-fold Mermaid diagrams with `IntersectionObserver`
- tighten the current permissive CSP after inventorying the exact analytics, forms, image, and comment origins
