### PR TITLE
Add personal publishing disclaimer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021 Timothy Lin
+Copyright (c) 2024-2026 Ylang Labs contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -104,11 +104,36 @@ export default function Footer() {
             ))}
           </div>
 
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-4 border-t border-gray-200 pt-8 text-sm text-gray-500 dark:border-white/10 lg:justify-between">
+          <section
+            aria-labelledby="site-disclaimer-title"
+            className="grid gap-3 border-y border-gray-200 py-6 text-sm leading-relaxed text-gray-600 dark:border-white/10 dark:text-gray-400 sm:grid-cols-[minmax(0,12rem)_minmax(0,1fr)] sm:gap-8"
+          >
+            <h2
+              id="site-disclaimer-title"
+              className="text-sm font-semibold uppercase tracking-wide text-gray-900 dark:text-gray-200"
+            >
+              Personal publishing note
+            </h2>
+            <p className="max-w-4xl">
+              Articles express their authors’ personal views and do not represent or imply
+              endorsement by any employer, client, or partner. We publish from public sources and
+              personal experience and do not knowingly include confidential, proprietary, or
+              employer-owned material. Original articles and site code are open source under the{' '}
+              <Link
+                href={`${siteMetadata.siteRepo}/blob/main/LICENSE`}
+                className="font-medium text-gray-900 underline decoration-gray-300 underline-offset-4 transition hover:decoration-primary-500 dark:text-gray-200 dark:decoration-gray-600 dark:hover:decoration-primary-400"
+              >
+                MIT License
+              </Link>{' '}
+              unless otherwise noted. Content is for educational purposes, not professional advice.
+            </p>
+          </section>
+
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-4 text-sm text-gray-500 lg:justify-between">
             <div className="flex items-center text-gray-600 dark:text-gray-500">
               <DynamicLogo />
             </div>
-            <div className="text-gray-600 dark:text-gray-500">{`© ${currentYear} ${siteMetadata.title}. All rights reserved.`}</div>
+            <div className="text-gray-600 dark:text-gray-500">{`© ${currentYear} ${siteMetadata.title}.`}</div>
             <div className="flex flex-wrap items-center gap-3 text-gray-600 dark:text-gray-500">
               {socialIconLinks.map(({ kind, href }) => (
                 <SocialIcon

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -7,7 +7,7 @@ const siteMetadata = {
   language: 'en-us',
   theme: 'light', // system, dark or light
   siteUrl: 'https://ylanglabs.com',
-  siteRepo: 'https://github.com/artreimus/ylang-labs',
+  siteRepo: 'https://github.com/artreimus/ylang-labs-blog',
   siteLogo: `${process.env.BASE_PATH || ''}/static/images/logo-white.png`,
   socialBanner: `${process.env.BASE_PATH || ''}/static/images/social-banner.png`,
   // mastodon: 'https://mastodon.social/@mastodonuser',

--- a/tests/components/Footer.test.tsx
+++ b/tests/components/Footer.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+
+import Footer from '@/components/Footer'
+
+describe('Footer', () => {
+  it('shows the site-wide personal publishing disclaimer and open-source license', () => {
+    render(<Footer />)
+
+    expect(screen.getByRole('heading', { name: 'Personal publishing note' })).toBeInTheDocument()
+    expect(screen.getByText(/authors’ personal views/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/do not knowingly include confidential, proprietary/i)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/educational purposes, not professional advice/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'MIT License' })).toHaveAttribute(
+      'href',
+      'https://github.com/artreimus/ylang-labs-blog/blob/main/LICENSE'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- add a site-wide personal publishing notice to the footer
- clarify that articles reflect their authors' views and are not employer, client, or partner endorsements
- state that confidential and proprietary material is not knowingly published
- link original articles and site code to the repository's MIT License
- align the repository metadata and copyright notice with the public Ylang Labs repository

## Why

Ylang Labs is a personal technical publication. The footer should make the publication's independence, source boundaries, educational purpose, and open-source terms clear without presenting an intrusive legal banner.

## Validation

- `pnpm test:unit` (15 tests passed)
- `pnpm lint` (0 errors; 2 pre-existing warnings)
- `pnpm build`
