### PR TITLE
Fix MIT license copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
 MIT License
 
-Copyright (c) 2021 Timothy Lin
 Copyright (c) 2024-2026 Ylang Labs contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
## Summary

- remove the stale Timothy Lin copyright notice
- retain the current Ylang Labs contributors notice

## Why

The repository license still credited the original template author even though the project is maintained as Ylang Labs.

## Impact

The MIT license text is unchanged; only the copyright attribution is corrected.

## Validation

- reviewed the final LICENSE diff
- ran git diff --check